### PR TITLE
Remove unused `require('stream')`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var Stream = require('stream');
 var toml = require('./lib/toml');
 
 module.exports = {


### PR DESCRIPTION
It doesn't actually do anything with the stream anymore.  Requiring it in will result in a lot of additional code being loaded though, especially if this module is used on the client.
