### PR TITLE
add jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+    "node": true,
+    "esnext": true,
+    "bitwise": true,
+    "curly": false,
+    "eqeqeq": false,
+    "eqnull": true,
+    "immed": true,
+    "latedef": "nofunc",
+    "newcap": false,
+    "noarg": true,
+    "undef": true,
+    "strict": false,
+    "trailing": true,
+    "smarttabs": true,
+    "indent": 2,
+    "white": false,
+    "quotmark": false,
+    "laxbreak": true,
+    "globals"   : {}
+}


### PR DESCRIPTION
`npm test` fails because jshint has some errors.

```
> toml@2.1.1 test /Users/stoeffel/src/tmp/toml-node
> jshint lib/compiler.js && nodeunit test/test_*.js

lib/compiler.js: line 10, col 3, Inner functions should be listed at the top of the outer function.
lib/compiler.js: line 10, col 18, 'reduce' was used before it was defined.
lib/compiler.js: line 48, col 22, Expected '===' and instead saw '=='.
lib/compiler.js: line 107, col 17, Expected '===' and instead saw '=='.
lib/compiler.js: line 130, col 25, Expected '!==' and instead saw '!='.
lib/compiler.js: line 139, col 23, Expected '===' and instead saw '=='.
lib/compiler.js: line 6, col 7, 'arrayMode' is defined but never used.

7 errors
npm ERR! Test failed.  See above for more details.
```

I guess this errors don't appear if you run jshint because of your global jshint settings.

This PR adds a `.jshintrc` so everyone can run `npm test`.
