### PR TITLE
Loose type check between  Integer and Float. Both of them are the same in the javascript context.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -171,11 +171,11 @@ function compile(nodes) {
       var node = array[i];
       if (firstType === null) {
         firstType = node.type;
-      } else {
-        if (node.type !== firstType) {
-          genError("Cannot add value of type " + node.type + " to array of type " +
-            firstType + ".", node.line, node.column);
-        }
+      } else if ((node.type === 'Integer' || node.type === 'Float') && (firstType === 'Integer' || firstType === 'Float')) {
+        // OK.
+      } else if (node.type !== firstType) {
+        genError("Cannot add value of type " + node.type + " to array of type " +
+          firstType + ".", node.line, node.column);
       }
     }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -171,7 +171,7 @@ function compile(nodes) {
       var node = array[i];
       if (firstType === null) {
         firstType = node.type;
-      } else if ((node.type === 'Integer' || node.type === 'Float') && (firstType === 'Integer' || firstType === 'Float')) {
+      } else if ((node.type === "Integer" || node.type === "Float") && (firstType === "Integer" || firstType === "Float")) {
         // OK.
       } else if (node.type !== firstType) {
         genError("Cannot add value of type " + node.type + " to array of type " +


### PR DESCRIPTION
Hi,

I got the error at loading a toml file below.
```
position = [51.01973684210527,15]
```

In JS context, both `Float` and `Integer` are the same type - `Number`, so I think, there is no need to distinguish between them.

I hope you check my change.
Thank you.
