### PR TITLE
Fix #40

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,7 +11,7 @@ function compile(nodes) {
 
   function reduce(nodes) {
     var node;
-    for (var i in nodes) {
+    for (var i = 0; i < nodes.length; i++) {
       node = nodes[i];
       switch (node.type) {
       case "Assign":
@@ -133,24 +133,22 @@ function compile(nodes) {
   // If `a` or `b` are arrays and have items in them, the last item in the
   // array is used as the context for the next sub-path.
   function deepRef(start, keys, value, line, column) {
-    var key;
     var traversed = [];
     var traversedPath = "";
     var path = keys.join(".");
     var ctx = start;
-    var keysLen = keys.length;
 
-    for (var i in keys) {
-      key = keys[i];
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       traversed.push(key);
       traversedPath = traversed.join(".");
       if (typeof ctx[key] === "undefined") {
-        if (i === String(keysLen - 1)) {
+        if (i === keys.length - 1) {
           ctx[key] = value;
         } else {
           ctx[key] = {};
         }
-      } else if (i !== keysLen - 1 && valueAssignments.indexOf(traversedPath) > -1) {
+      } else if (i !== keys.length - 1 && valueAssignments.indexOf(traversedPath) > -1) {
         // already a non-object value at key, can't be used as part of a new path
         genError("Cannot redefine existing key '" + traversedPath + "'.", line, column);
       }
@@ -167,7 +165,7 @@ function compile(nodes) {
   function reduceArrayWithTypeChecking(array) {
     // Ensure that all items in the array are of the same type
     var firstType = null;
-    for(var i in array) {
+    for (var i = 0; i < array.length; i++) {
       var node = array[i];
       if (firstType === null) {
         firstType = node.type;

--- a/test/table_arrays_hard.toml
+++ b/test/table_arrays_hard.toml
@@ -1,4 +1,8 @@
 [[fruit]]
+name = "durian"
+variety = []
+
+[[fruit]]
 name = "apple"
 
   [fruit.physical]

--- a/test/test_toml.js
+++ b/test/test_toml.js
@@ -72,6 +72,10 @@ var easyTableArrayExpected = {
 var hardTableArrayExpected = {
   "fruit": [
     {
+      "name": "durian",
+      "variety": []
+    },
+    {
       "name": "apple",
       "physical": {
         "color": "red",


### PR DESCRIPTION
This patch tweaks a testcase to trigger the bug, and fixes the bug.

The bug is because `deepRef` does
```
for (var i in keys) {
   if (i !== keysLen - 1) ...
```
which is always false, because `for..in` always produces string indexes, so `i` is a string, not a number.

This patch fixes all the `for..in` array loops to iterate over numeric indexes, not string indexes.