### PR TITLE
Create all objects without prototypes

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -76,7 +76,7 @@ function compile(nodes) {
   }
 
   function reduceInlineTableNode(values) {
-    var obj = {};
+    var obj = Object.create(null);
     for (var i = 0; i < values.length; i++) {
       var val = values[i];
       if (val.value.type === "InlineTable") {
@@ -99,7 +99,7 @@ function compile(nodes) {
       genError("Cannot redefine existing key '" + path + "'.", line, column);
     }
     assignedPaths.push(quotedPath);
-    context = deepRef(data, path, {}, line, column);
+    context = deepRef(data, path, Object.create(null), line, column);
     currentPath = path;
   }
 
@@ -120,7 +120,7 @@ function compile(nodes) {
     currentPath = quotedPath;
 
     if (context instanceof Array) {
-      var newObj = {};
+      var newObj = Object.create(null);
       context.push(newObj);
       context = newObj;
     } else {
@@ -146,7 +146,7 @@ function compile(nodes) {
         if (i === keys.length - 1) {
           ctx[key] = value;
         } else {
-          ctx[key] = {};
+          ctx[key] = Object.create(null);
         }
       } else if (i !== keys.length - 1 && valueAssignments.indexOf(traversedPath) > -1) {
         // already a non-object value at key, can't be used as part of a new path

--- a/test/test_toml.js
+++ b/test/test_toml.js
@@ -586,10 +586,10 @@ exports.testErrorsHaveCorrectLineAndColumn = function(test) {
 };
 
 exports.testUsingConstructorAsKey = function(test) {
-  test.parsesToml("[empty]\n[emptier]\n[constructor]\n[emptiest]", {
+  test.parsesToml("[empty]\n[emptier]\n[constructor]\nconstructor = 1\n[emptiest]", {
     "empty": {},
     "emptier": {},
-    "constructor": {},
+    "constructor": { "constructor": 1 },
     "emptiest": {}
   });
   test.done();


### PR DESCRIPTION
Follow-up to #53, allows "constructor" and other keys normally on the object prototype to be used as TOML keys.