### PR TITLE
✨ Improve type definition of `parse` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ try {
 }
 ```
 
+In TypeScript you can tell what's the type of the parsed data like so:
+
+```typescript
+var toml = require('toml');
+type MyData = { foo: number };
+var data = toml.parse<MyData>(someTomlString);
+console.dir(data);
+```
+
 ### Streaming
 
 As of toml-node version 1.0, the streaming interface has been removed. Instead, use a module like [concat-stream](https://npmjs.org/package/concat-stream):

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'toml' {
-  export function parse(input: string): any;
+  export function parse<TParsedData = any>(input: string): TParsedData;
 }


### PR DESCRIPTION
Now users can optionally supply the type of the parsed data like the following:

```ts
const myData = toml.parse<MyData>(myInput);
//        ^? MyData
```

instead of doing

```ts
const myData: MyData = toml.parse(myInput);
```

Notice that the default type is still `any` thus both approach above works.

---

As an workaround to this, I augmented `toml` with this ambient file:

<details>
<summary><code>toml.d.ts</code></summary>

```ts
declare module 'toml' {
  export function parse<TOutput = any>(input: string): TOutput;
}
```

</details>