### PR TITLE
Improve performance ~5x

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var compiler = require('./lib/compiler');
 
 module.exports = {
   parse: function(input) {
-    var nodes = parser.parse(input.toString());
-    return compiler.compile(nodes);
+    var str = input.toString();
+    var nodes = parser.parse(str);
+    return compiler.compile(nodes, str);
   }
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,13 +1,11 @@
 "use strict";
-function compile(nodes) {
-  var assignedPaths = [];
-  var valueAssignments = [];
-  var explicitTablePaths = [];
-  var tableArrayPaths = [];
+function compile(nodes, inputText) {
+  var assignedPaths = new Set();
+  var valueAssignments = new Set();
+  var explicitTablePaths = new Set();
   var currentPath = "";
   var data = Object.create(null);
   var context = data;
-  var arrayMode = false;
 
   return reduce(nodes);
 
@@ -31,25 +29,32 @@ function compile(nodes) {
     return data;
   }
 
-  function genError(err, line, col) {
+  function resolveLineCol(off) {
+    var line = 1, col = 1;
+    for (var i = 0; i < off; i++) {
+      if (inputText.charCodeAt(i) === 10) { line++; col = 1; }
+      else { col++; }
+    }
+    return { line: line, column: col };
+  }
+
+  function genError(err, off) {
+    var pos = resolveLineCol(off);
     var ex = new Error(err);
-    ex.line = line;
-    ex.column = col;
+    ex.line = pos.line;
+    ex.column = pos.column;
     throw ex;
   }
 
   function assign(node) {
     var keys = node.key;
     var value = node.value;
-    var line = node.line;
-    var column = node.column;
+    var off = node.offset;
 
-    // Support both legacy single-string keys and new array-of-keys format
     if (!Array.isArray(keys)) keys = [keys];
 
     var reduced = reduceValueNode(value);
 
-    // Navigate to the right context for dotted keys, creating intermediate tables
     var target = context;
     for (var i = 0; i < keys.length - 1; i++) {
       var k = keys[i];
@@ -57,15 +62,13 @@ function compile(nodes) {
 
       if (typeof target[k] === "undefined") {
         target[k] = Object.create(null);
-        if (!pathAssigned(intermediatePath)) {
-          assignedPaths.push(intermediatePath);
-        }
+        assignedPaths.add(intermediatePath);
       } else if (typeof target[k] !== "object" || target[k] === null || Array.isArray(target[k])) {
-        genError("Cannot redefine existing key '" + intermediatePath + "'.", line, column);
-      } else if (valueAssignments.indexOf(intermediatePath) > -1) {
-        genError("Cannot redefine existing key '" + intermediatePath + "'.", line, column);
-      } else if (explicitTablePaths.indexOf(intermediatePath) > -1 && intermediatePath !== (Array.isArray(currentPath) ? currentPath.join(".") : currentPath)) {
-        genError("Cannot use dotted keys to extend table '" + intermediatePath + "' defined elsewhere.", line, column);
+        genError("Cannot redefine existing key '" + intermediatePath + "'.", off);
+      } else if (valueAssignments.has(intermediatePath)) {
+        genError("Cannot redefine existing key '" + intermediatePath + "'.", off);
+      } else if (explicitTablePaths.has(intermediatePath) && intermediatePath !== (Array.isArray(currentPath) ? currentPath.join(".") : currentPath)) {
+        genError("Cannot use dotted keys to extend table '" + intermediatePath + "' defined elsewhere.", off);
       }
       target = target[k];
     }
@@ -74,21 +77,15 @@ function compile(nodes) {
     var fullPath = currentPath ? currentPath + "." + keys.join(".") : keys.join(".");
 
     if (typeof target[lastKey] !== "undefined") {
-      genError("Cannot redefine existing key '" + fullPath + "'.", line, column);
+      genError("Cannot redefine existing key '" + fullPath + "'.", off);
     }
 
     target[lastKey] = reduced;
 
-    if (!pathAssigned(fullPath)) {
-      assignedPaths.push(fullPath);
-      valueAssignments.push(fullPath);
-    }
+    assignedPaths.add(fullPath);
+    valueAssignments.add(fullPath);
   }
 
-
-  function pathAssigned(path) {
-    return assignedPaths.indexOf(path) !== -1;
-  }
 
   function reduceValueNode(node) {
     if (node.type === "Array") {
@@ -102,10 +99,7 @@ function compile(nodes) {
 
   function reduceInlineTableNode(values) {
     var obj = Object.create(null);
-    // Track paths that were explicitly defined (either as values or as inline
-    // table results). Dotted keys can create implicit intermediate tables but
-    // cannot modify explicitly defined ones.
-    var definedKeys = [];
+    var definedKeys = new Set();
 
     for (var i = 0; i < values.length; i++) {
       var val = values[i];
@@ -115,32 +109,30 @@ function compile(nodes) {
       if (!Array.isArray(keys)) keys = [keys];
 
       var reduced = reduceValueNode(val.value);
-      setNestedKey(obj, keys, reduced, val.line, val.column, definedKeys);
+      setNestedKey(obj, keys, reduced, val.offset, definedKeys);
 
-      // Track the full path as a defined key
-      definedKeys.push(keys.join("."));
+      definedKeys.add(keys.join("."));
     }
 
     return obj;
   }
 
-  function setNestedKey(obj, keys, value, line, column, definedKeys) {
+  function setNestedKey(obj, keys, value, off, definedKeys) {
     for (var i = 0; i < keys.length - 1; i++) {
       var k = keys[i];
       var intermediatePath = keys.slice(0, i + 1).join(".");
       if (typeof obj[k] === "undefined") {
         obj[k] = Object.create(null);
       } else if (typeof obj[k] !== "object" || obj[k] === null || Array.isArray(obj[k])) {
-        genError("Cannot redefine existing key '" + intermediatePath + "'.", line, column);
-      } else if (definedKeys && definedKeys.indexOf(intermediatePath) > -1) {
-        // Cannot extend an explicitly-defined inline table
-        genError("Cannot extend inline table '" + intermediatePath + "'.", line, column);
+        genError("Cannot redefine existing key '" + intermediatePath + "'.", off);
+      } else if (definedKeys && definedKeys.has(intermediatePath)) {
+        genError("Cannot extend inline table '" + intermediatePath + "'.", off);
       }
       obj = obj[k];
     }
     var lastKey = keys[keys.length - 1];
     if (typeof obj[lastKey] !== "undefined") {
-      genError("Cannot redefine existing key '" + keys.join(".") + "'.", line, column);
+      genError("Cannot redefine existing key '" + keys.join(".") + "'.", off);
     }
     obj[lastKey] = value;
   }
@@ -148,40 +140,35 @@ function compile(nodes) {
   function setPath(node) {
     var path = node.value;
     var quotedPath = path.map(quoteDottedString).join(".");
-    var line = node.line;
-    var column = node.column;
+    var off = node.offset;
 
-    if (pathAssigned(quotedPath)) {
-      genError("Cannot redefine existing key '" + path + "'.", line, column);
+    if (assignedPaths.has(quotedPath)) {
+      genError("Cannot redefine existing key '" + path + "'.", off);
     }
-    assignedPaths.push(quotedPath);
-    explicitTablePaths.push(quotedPath);
-    context = deepRef(data, path, Object.create(null), line, column);
+    assignedPaths.add(quotedPath);
+    explicitTablePaths.add(quotedPath);
+    context = deepRef(data, path, Object.create(null), off);
     currentPath = path;
   }
 
   function addTableArray(node) {
     var path = node.value;
     var quotedPath = path.map(quoteDottedString).join(".");
-    var line = node.line;
-    var column = node.column;
+    var off = node.offset;
 
-    // Check before filtering: cannot append to a statically-defined array
-    if (valueAssignments.indexOf(quotedPath) > -1) {
-      genError("Cannot append to statically defined array '" + quotedPath + "'.", line, column);
+    if (valueAssignments.has(quotedPath)) {
+      genError("Cannot append to statically defined array '" + quotedPath + "'.", off);
     }
 
-    if (!pathAssigned(quotedPath)) {
-      assignedPaths.push(quotedPath);
-    }
-    assignedPaths = assignedPaths.filter(function(p) {
-      return p.indexOf(quotedPath) !== 0;
+    // Clear paths that start with this table array path
+    assignedPaths.forEach(function(p) {
+      if (p.indexOf(quotedPath) === 0) assignedPaths.delete(p);
     });
-    valueAssignments = valueAssignments.filter(function(p) {
-      return p.indexOf(quotedPath) !== 0;
+    valueAssignments.forEach(function(p) {
+      if (p.indexOf(quotedPath) === 0) valueAssignments.delete(p);
     });
-    assignedPaths.push(quotedPath);
-    context = deepRef(data, path, [], line, column);
+    assignedPaths.add(quotedPath);
+    context = deepRef(data, path, [], off);
     currentPath = quotedPath;
 
     if (context instanceof Array) {
@@ -189,33 +176,25 @@ function compile(nodes) {
       context.push(newObj);
       context = newObj;
     } else {
-      genError("Cannot redefine existing key '" + path + "'.", line, column);
+      genError("Cannot redefine existing key '" + path + "'.", off);
     }
   }
 
-  // Given a path 'a.b.c', create (as necessary) `start.a`,
-  // `start.a.b`, and `start.a.b.c`, assigning `value` to `start.a.b.c`.
-  // If `a` or `b` are arrays and have items in them, the last item in the
-  // array is used as the context for the next sub-path.
-  function deepRef(start, keys, value, line, column) {
-    var traversed = [];
+  function deepRef(start, keys, value, off) {
     var traversedPath = "";
-    var path = keys.join(".");
     var ctx = start;
 
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
-      traversed.push(key);
-      traversedPath = traversed.join(".");
+      traversedPath = traversedPath ? traversedPath + "." + key : key;
       if (typeof ctx[key] === "undefined") {
         if (i === keys.length - 1) {
           ctx[key] = value;
         } else {
           ctx[key] = Object.create(null);
         }
-      } else if (i !== keys.length - 1 && valueAssignments.indexOf(traversedPath) > -1) {
-        // already a non-object value at key, can't be used as part of a new path
-        genError("Cannot redefine existing key '" + traversedPath + "'.", line, column);
+      } else if (i !== keys.length - 1 && valueAssignments.has(traversedPath)) {
+        genError("Cannot redefine existing key '" + traversedPath + "'.", off);
       }
 
       ctx = ctx[key];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -170,16 +170,16 @@ function peg$parse(input, options) {
   const peg$c2 = "]";
   const peg$c3 = ".";
   const peg$c4 = "=";
-  const peg$c5 = "\"\"\"";
-  const peg$c6 = "\"";
-  const peg$c7 = "'''";
-  const peg$c8 = "'";
-  const peg$c9 = "\\";
-  const peg$c10 = "\r\n";
-  const peg$c11 = "\"\"";
-  const peg$c12 = "''";
-  const peg$c13 = "inf";
-  const peg$c14 = "nan";
+  const peg$c5 = "inf";
+  const peg$c6 = "nan";
+  const peg$c7 = "\"\"\"";
+  const peg$c8 = "\"";
+  const peg$c9 = "'''";
+  const peg$c10 = "'";
+  const peg$c11 = "\\";
+  const peg$c12 = "\r\n";
+  const peg$c13 = "\"\"";
+  const peg$c14 = "''";
   const peg$c15 = "0";
   const peg$c16 = "0x";
   const peg$c17 = "0o";
@@ -196,197 +196,166 @@ function peg$parse(input, options) {
   const peg$c28 = " ";
   const peg$c29 = "\n";
   const peg$c30 = "\r";
-  const peg$c31 = "\\\"";
-  const peg$c32 = "\\\\";
-  const peg$c33 = "\\b";
-  const peg$c34 = "\\t";
-  const peg$c35 = "\\n";
-  const peg$c36 = "\\f";
-  const peg$c37 = "\\r";
-  const peg$c38 = "\\e";
-  const peg$c39 = "\\U";
-  const peg$c40 = "\\u";
-  const peg$c41 = "\\x";
+  const peg$c31 = "\\U";
+  const peg$c32 = "\\u";
+  const peg$c33 = "\\x";
 
-  const peg$r0 = /^[+\-]/;
-  const peg$r1 = /^[eE]/;
-  const peg$r2 = /^[0-9_]/;
-  const peg$r3 = /^[1-9]/;
-  const peg$r4 = /^[_]/;
-  const peg$r5 = /^[0-9]/;
-  const peg$r6 = /^[0-9a-fA-F]/;
-  const peg$r7 = /^[0-7]/;
-  const peg$r8 = /^[01]/;
-  const peg$r9 = /^[ \t]/;
-  const peg$r10 = /^[A-Za-z0-9_\-]/;
+  const peg$r0 = /^[\t -~\x80-\uFFFF]/;
+  const peg$r1 = /^[+\-]/;
+  const peg$r2 = /^[^"\\\0-\b\v-\x1F\x7F\r]/;
+  const peg$r3 = /^[^'\0-\b\v-\x1F\x7F\r]/;
+  const peg$r4 = /^[^"\\\0-\b\n-\x1F\x7F]/;
+  const peg$r5 = /^[^'\0-\b\n-\x1F\x7F]/;
+  const peg$r6 = /^[eE]/;
+  const peg$r7 = /^[0-9_]/;
+  const peg$r8 = /^[1-9]/;
+  const peg$r9 = /^[_]/;
+  const peg$r10 = /^[0-9]/;
+  const peg$r11 = /^[0-9a-fA-F]/;
+  const peg$r12 = /^[0-7]/;
+  const peg$r13 = /^[01]/;
+  const peg$r14 = /^[ \t]/;
+  const peg$r15 = /^[A-Za-z0-9_\-]/;
+  const peg$r16 = /^["\\btnfre]/;
 
   const peg$e0 = peg$literalExpectation("#", false);
-  const peg$e1 = peg$anyExpectation();
+  const peg$e1 = peg$classExpectation(["\t", [" ", "~"], ["\x80", "\uFFFF"]], false, false, false);
   const peg$e2 = peg$literalExpectation("[", false);
   const peg$e3 = peg$literalExpectation("]", false);
   const peg$e4 = peg$literalExpectation(".", false);
   const peg$e5 = peg$literalExpectation("=", false);
-  const peg$e6 = peg$literalExpectation("\"\"\"", false);
-  const peg$e7 = peg$literalExpectation("\"", false);
-  const peg$e8 = peg$literalExpectation("'''", false);
-  const peg$e9 = peg$literalExpectation("'", false);
-  const peg$e10 = peg$literalExpectation("\\", false);
-  const peg$e11 = peg$literalExpectation("\r\n", false);
-  const peg$e12 = peg$literalExpectation("\"\"", false);
-  const peg$e13 = peg$literalExpectation("''", false);
-  const peg$e14 = peg$classExpectation(["+", "-"], false, false, false);
-  const peg$e15 = peg$literalExpectation("inf", false);
-  const peg$e16 = peg$literalExpectation("nan", false);
-  const peg$e17 = peg$classExpectation(["e", "E"], false, false, false);
-  const peg$e18 = peg$literalExpectation("0", false);
-  const peg$e19 = peg$literalExpectation("0x", false);
-  const peg$e20 = peg$literalExpectation("0o", false);
-  const peg$e21 = peg$literalExpectation("0b", false);
-  const peg$e22 = peg$classExpectation([["0", "9"], "_"], false, false, false);
-  const peg$e23 = peg$classExpectation([["1", "9"]], false, false, false);
-  const peg$e24 = peg$classExpectation(["_"], false, false, false);
-  const peg$e25 = peg$classExpectation([["0", "9"]], false, false, false);
-  const peg$e26 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false, false);
-  const peg$e27 = peg$classExpectation([["0", "7"]], false, false, false);
-  const peg$e28 = peg$classExpectation(["0", "1"], false, false, false);
-  const peg$e29 = peg$literalExpectation("true", false);
-  const peg$e30 = peg$literalExpectation("false", false);
-  const peg$e31 = peg$literalExpectation(",", false);
-  const peg$e32 = peg$literalExpectation("{", false);
-  const peg$e33 = peg$literalExpectation("}", false);
-  const peg$e34 = peg$literalExpectation("-", false);
-  const peg$e35 = peg$literalExpectation(":", false);
-  const peg$e36 = peg$literalExpectation("Z", true);
-  const peg$e37 = peg$literalExpectation("T", true);
-  const peg$e38 = peg$literalExpectation(" ", false);
-  const peg$e39 = peg$classExpectation([" ", "\t"], false, false, false);
-  const peg$e40 = peg$literalExpectation("\n", false);
-  const peg$e41 = peg$literalExpectation("\r", false);
-  const peg$e42 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", "-"], false, false, false);
-  const peg$e43 = peg$literalExpectation("\\\"", false);
-  const peg$e44 = peg$literalExpectation("\\\\", false);
-  const peg$e45 = peg$literalExpectation("\\b", false);
-  const peg$e46 = peg$literalExpectation("\\t", false);
-  const peg$e47 = peg$literalExpectation("\\n", false);
-  const peg$e48 = peg$literalExpectation("\\f", false);
-  const peg$e49 = peg$literalExpectation("\\r", false);
-  const peg$e50 = peg$literalExpectation("\\e", false);
-  const peg$e51 = peg$literalExpectation("\\U", false);
-  const peg$e52 = peg$literalExpectation("\\u", false);
-  const peg$e53 = peg$literalExpectation("\\x", false);
+  const peg$e6 = peg$classExpectation(["+", "-"], false, false, false);
+  const peg$e7 = peg$literalExpectation("inf", false);
+  const peg$e8 = peg$literalExpectation("nan", false);
+  const peg$e9 = peg$literalExpectation("\"\"\"", false);
+  const peg$e10 = peg$literalExpectation("\"", false);
+  const peg$e11 = peg$literalExpectation("'''", false);
+  const peg$e12 = peg$literalExpectation("'", false);
+  const peg$e13 = peg$literalExpectation("\\", false);
+  const peg$e14 = peg$anyExpectation();
+  const peg$e15 = peg$literalExpectation("\r\n", false);
+  const peg$e16 = peg$classExpectation(["\"", "\\", ["\0", "\b"], ["\v", "\x1F"], "\x7F", "\r"], true, false, false);
+  const peg$e17 = peg$literalExpectation("\"\"", false);
+  const peg$e18 = peg$classExpectation(["'", ["\0", "\b"], ["\v", "\x1F"], "\x7F", "\r"], true, false, false);
+  const peg$e19 = peg$literalExpectation("''", false);
+  const peg$e20 = peg$classExpectation(["\"", "\\", ["\0", "\b"], ["\n", "\x1F"], "\x7F"], true, false, false);
+  const peg$e21 = peg$classExpectation(["'", ["\0", "\b"], ["\n", "\x1F"], "\x7F"], true, false, false);
+  const peg$e22 = peg$classExpectation(["e", "E"], false, false, false);
+  const peg$e23 = peg$literalExpectation("0", false);
+  const peg$e24 = peg$literalExpectation("0x", false);
+  const peg$e25 = peg$literalExpectation("0o", false);
+  const peg$e26 = peg$literalExpectation("0b", false);
+  const peg$e27 = peg$classExpectation([["0", "9"], "_"], false, false, false);
+  const peg$e28 = peg$classExpectation([["1", "9"]], false, false, false);
+  const peg$e29 = peg$classExpectation(["_"], false, false, false);
+  const peg$e30 = peg$classExpectation([["0", "9"]], false, false, false);
+  const peg$e31 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false, false);
+  const peg$e32 = peg$classExpectation([["0", "7"]], false, false, false);
+  const peg$e33 = peg$classExpectation(["0", "1"], false, false, false);
+  const peg$e34 = peg$literalExpectation("true", false);
+  const peg$e35 = peg$literalExpectation("false", false);
+  const peg$e36 = peg$literalExpectation(",", false);
+  const peg$e37 = peg$literalExpectation("{", false);
+  const peg$e38 = peg$literalExpectation("}", false);
+  const peg$e39 = peg$literalExpectation("-", false);
+  const peg$e40 = peg$literalExpectation(":", false);
+  const peg$e41 = peg$literalExpectation("Z", true);
+  const peg$e42 = peg$literalExpectation("T", true);
+  const peg$e43 = peg$literalExpectation(" ", false);
+  const peg$e44 = peg$classExpectation([" ", "\t"], false, false, false);
+  const peg$e45 = peg$literalExpectation("\n", false);
+  const peg$e46 = peg$literalExpectation("\r", false);
+  const peg$e47 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", "-"], false, false, false);
+  const peg$e48 = peg$classExpectation(["\"", "\\", "b", "t", "n", "f", "r", "e"], false, false, false);
+  const peg$e49 = peg$literalExpectation("\\U", false);
+  const peg$e50 = peg$literalExpectation("\\u", false);
+  const peg$e51 = peg$literalExpectation("\\x", false);
 
   function peg$f0() {    return nodes  }
-  function peg$f1(char) {    if (isControlChar(char)) genError("Control characters are not allowed in comments", location().start.line, location().start.column); return char  }
-  function peg$f2(name) {    addNode(node('ObjectPath', name, location()))  }
-  function peg$f3(name) {    addNode(node('ArrayPath', name, location()))  }
-  function peg$f4(parts, name) {    return parts.concat(name)  }
-  function peg$f5(name) {    return [name]  }
+  function peg$f1(name) {    addNode(node('ArrayPath', name, offset()))  }
+  function peg$f2(name) {    addNode(node('ObjectPath', name, offset()))  }
+  function peg$f3(parts, name) {    return parts.concat(name)  }
+  function peg$f4(name) {    return [name]  }
+  function peg$f5(name) {    return name  }
   function peg$f6(name) {    return name  }
-  function peg$f7(name) {    return name  }
-  function peg$f8(name) {    return name  }
-  function peg$f9(name) {    return name  }
-  function peg$f10(keys, value) {    addNode(node('Assign', value, location(), keys))  }
-  function peg$f11(chars) {    return chars.join('')  }
-  function peg$f12(node) {    return node.value  }
-  function peg$f13(node) {    return node.value  }
-  function peg$f14(body) {    return node('String', body, location())  }
-  function peg$f15(chars) {    return node('String', chars.join(''), location())  }
-  function peg$f16(body) {    return node('String', body, location())  }
-  function peg$f17(chars) {    return node('String', chars.join(''), location())  }
-  function peg$f18(head, parts, tail) {
+  function peg$f7(keys, value) {    addNode(node('Assign', value, offset(), keys))  }
+  function peg$f8(node) {    return node.value  }
+  function peg$f9(node) {    return node.value  }
+  function peg$f10(sign) {    return node('Float', sign === '-' ? -Infinity : Infinity, offset())  }
+  function peg$f11(sign) {    return node('Float', NaN, offset())  }
+  function peg$f12(body) {    return node('String', body, offset())  }
+  function peg$f13(chars) {    return node('String', chars.join(''), offset())  }
+  function peg$f14(body) {    return node('String', body, offset())  }
+  function peg$f15(chars) {    return node('String', chars.join(''), offset())  }
+  function peg$f16(head, parts, tail) {
     var result = head.join('');
     for (var i = 0; i < parts.length; i++) { result += parts[i][0] + parts[i][1].join(''); }
     return result + (tail || '');
   }
-  function peg$f19() {    genError("Invalid escape sequence", location().start.line, location().start.column)  }
-  function peg$f20() {    return "\n"  }
-  function peg$f21(char) {    if (isControlCharMultiline(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char  }
-  function peg$f22() {    return ''  }
-  function peg$f23() {    return '""'  }
-  function peg$f24() {    return '"'  }
-  function peg$f25() {    return '""'  }
-  function peg$f26() {    return '"'  }
-  function peg$f27(head, parts, tail) {
+  function peg$f17() {    genError("Invalid escape sequence", offset())  }
+  function peg$f18() {    return "\n"  }
+  function peg$f19() {    return ''  }
+  function peg$f20() {    return '""'  }
+  function peg$f21() {    return '"'  }
+  function peg$f22() {    return '""'  }
+  function peg$f23() {    return '"'  }
+  function peg$f24(head, parts, tail) {
     var result = head.join('');
     for (var i = 0; i < parts.length; i++) { result += parts[i][0] + parts[i][1].join(''); }
     return result + (tail || '');
   }
-  function peg$f28() {    return "\n"  }
-  function peg$f29(char) {    if (isControlCharMultiline(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char  }
-  function peg$f30() {    return "''"  }
-  function peg$f31() {    return "'"  }
-  function peg$f32() {    return "''"  }
-  function peg$f33() {    return "'"  }
-  function peg$f34() {    genError("Invalid escape sequence", location().start.line, location().start.column)  }
-  function peg$f35(char) {    if (isControlChar(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char  }
-  function peg$f36(char) {    if (isControlChar(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char  }
-  function peg$f37(sign) {    return node('Float', sign === '-' ? -Infinity : Infinity, location())  }
-  function peg$f38(sign) {    return node('Float', NaN, location())  }
-  function peg$f39(left, right) {    return node('Float', parseFloat(stripUnderscores(left + 'e' + right)), location())  }
-  function peg$f40(text) {    return node('Float', parseFloat(stripUnderscores(text)), location())  }
-  function peg$f41(sign, digits, frac) {    return (sign === '-' ? '-' : '') + digits + '.' + frac  }
-  function peg$f42(sign, digits, frac) {    return (sign === '-' ? '-' : '') + digits + '.' + frac  }
-  function peg$f43(sign, digits) {    return (sign === '-' ? '-' : '') + digits  }
-  function peg$f44() {    return '0'  }
-  function peg$f45(sign, digits) {    return (sign || '') + digits  }
-  function peg$f46(digits) {    return node('Integer', parseInt(stripUnderscores(digits), 16), location())  }
-  function peg$f47(digits) {    return node('Integer', parseInt(stripUnderscores(digits), 8), location())  }
-  function peg$f48(digits) {    return node('Integer', parseInt(stripUnderscores(digits), 2), location())  }
-  function peg$f49(text) {    return node('Integer', parseInt(stripUnderscores(text), 10), location())  }
-  function peg$f50(sign) {    return (sign || '') + '0'  }
-  function peg$f51(sign, digits) {    return (sign || '') + digits  }
-  function peg$f52(head, tail) {    return head + tail.map(function(p) { return p.join('') }).join('')  }
-  function peg$f53(head, tail) {    return head + tail.map(function(p) { return p.join('') }).join('')  }
-  function peg$f54(head, tail) {    return head + tail.map(function(p) { return p.join('') }).join('')  }
-  function peg$f55(head, tail) {    return head + tail.map(function(p) { return p.join('') }).join('')  }
-  function peg$f56(head, tail) {    return head + tail.map(function(p) { return p.join('') }).join('')  }
-  function peg$f57() {    return node('Boolean', true, location())  }
-  function peg$f58() {    return node('Boolean', false, location())  }
-  function peg$f59() {    return node('Array', [], location())  }
-  function peg$f60(value) {    return node('Array', value ? [value] : [], location())  }
-  function peg$f61(values) {    return node('Array', values, location())  }
-  function peg$f62(values, value) {    return node('Array', values.concat(value), location())  }
-  function peg$f63(value) {    return value  }
-  function peg$f64(value) {    return value  }
-  function peg$f65() {    return node('InlineTable', [], location())  }
-  function peg$f66(entries, last) {    return node('InlineTable', entries.concat(last), location())  }
-  function peg$f67(entries) {    return node('InlineTable', entries, location())  }
-  function peg$f68(entry) {    return node('InlineTable', [entry], location())  }
-  function peg$f69(e) {    return e  }
-  function peg$f70(entries) {    return entries  }
-  function peg$f71(keys, value) {    return node('InlineTableValue', value, location(), keys)  }
-  function peg$f72(parts, last) {    return parts.concat(last)  }
-  function peg$f73(k) {    return [k]  }
-  function peg$f74(k) {    return k  }
-  function peg$f75(digits) {    return "." + digits.join('')  }
-  function peg$f76(d) {    return d.join('')  }
-  function peg$f77(t) {    return t.join('')  }
-  function peg$f78(t) {    return t.join('') + ':00'  }
-  function peg$f79() {    return "Z"  }
-  function peg$f80(sign, h, m) {    return sign + h.join('') + ":" + m.join('')  }
-  function peg$f81(d, t, o) {    validateDate(d, location()); validateTime(t, location()); validateOffset(o, location()); return node('Date', new Date(d + "T" + t + o), location())  }
-  function peg$f82(d, t) {    validateDate(d, location()); validateTime(t, location()); return node('LocalDateTime', d + "T" + t, location())  }
-  function peg$f83(d) {    validateDate(d, location()); return node('LocalDate', d, location())  }
-  function peg$f84(t) {    validateTime(t, location()); return node('LocalTime', t, location())  }
-  function peg$f85() {    return '"'  }
-  function peg$f86() {    return '\\'  }
-  function peg$f87() {    return '\b'  }
-  function peg$f88() {    return '\t'  }
-  function peg$f89() {    return '\n'  }
-  function peg$f90() {    return '\f'  }
-  function peg$f91() {    return '\r'  }
-  function peg$f92() {    return '\x1B'  }
-  function peg$f93(digits) {    return convertCodePoint(digits.join(''))  }
-  function peg$f94(digits) {    return convertCodePoint(digits.join(''))  }
-  function peg$f95(digits) {    return convertCodePoint(digits.join(''))  }
+  function peg$f25() {    return "\n"  }
+  function peg$f26() {    return "''"  }
+  function peg$f27() {    return "'"  }
+  function peg$f28() {    return "''"  }
+  function peg$f29() {    return "'"  }
+  function peg$f30() {    genError("Invalid escape sequence", offset())  }
+  function peg$f31(left, right) {    return node('Float', parseFloat(stripUnderscores(left + 'e' + right)), offset())  }
+  function peg$f32(text) {    return node('Float', parseFloat(stripUnderscores(text)), offset())  }
+  function peg$f33(sign, digits, frac) {    return (sign === '-' ? '-' : '') + digits + '.' + frac  }
+  function peg$f34(sign, digits, frac) {    return (sign === '-' ? '-' : '') + digits + '.' + frac  }
+  function peg$f35(sign, digits) {    return (sign === '-' ? '-' : '') + digits  }
+  function peg$f36() {    return '0'  }
+  function peg$f37(sign, digits) {    return (sign || '') + digits  }
+  function peg$f38(digits) {    return node('Integer', parseInt(stripUnderscores(digits), 16), offset())  }
+  function peg$f39(digits) {    return node('Integer', parseInt(stripUnderscores(digits), 8), offset())  }
+  function peg$f40(digits) {    return node('Integer', parseInt(stripUnderscores(digits), 2), offset())  }
+  function peg$f41(text) {    return node('Integer', parseInt(stripUnderscores(text), 10), offset())  }
+  function peg$f42(sign) {    return (sign || '') + '0'  }
+  function peg$f43(sign, digits) {    return (sign || '') + digits  }
+  function peg$f44() {    return node('Boolean', true, offset())  }
+  function peg$f45() {    return node('Boolean', false, offset())  }
+  function peg$f46() {    return node('Array', [], offset())  }
+  function peg$f47(head, v) {    return v  }
+  function peg$f48(head, tail) {
+    tail.unshift(head); return node('Array', tail, offset())
+  }
+  function peg$f49() {    return node('InlineTable', [], offset())  }
+  function peg$f50(head, e) {    return e  }
+  function peg$f51(head, tail) {
+    tail.unshift(head); return node('InlineTable', tail, offset())
+  }
+  function peg$f52(keys, value) {    return node('InlineTableValue', value, offset(), keys)  }
+  function peg$f53(parts, last) {    return parts.concat(last)  }
+  function peg$f54(k) {    return [k]  }
+  function peg$f55(k) {    return k  }
+  function peg$f56(t, frac) {    return frac ? t + frac : t  }
+  function peg$f57(t) {    return t + ':00'  }
+  function peg$f58() {    return "Z"  }
+  function peg$f59(d, t, o) {    var off = offset(); validateDate(d, off); validateTime(t, off); validateOffset(o, off); return node('Date', new Date(d + "T" + t + o), off)  }
+  function peg$f60(d, t) {    var off = offset(); validateDate(d, off); validateTime(t, off); return node('LocalDateTime', d + "T" + t, off)  }
+  function peg$f61(d) {    var off = offset(); validateDate(d, off); return node('LocalDate', d, off)  }
+  function peg$f62(t) {    var off = offset(); validateTime(t, off); return node('LocalTime', t, off)  }
+  function peg$f63(ch) {    return ch === 'n' ? '\n' : ch === 't' ? '\t' : ch === 'r' ? '\r' : ch === '\\' ? '\\' : ch === '"' ? '"' : ch === 'b' ? '\b' : ch === 'f' ? '\f' : '\x1B'  }
+  function peg$f64(digits) {    return convertCodePoint(digits)  }
+  function peg$f65(digits) {    return convertCodePoint(digits)  }
+  function peg$f66(digits) {    return convertCodePoint(digits)  }
   let peg$currPos = options.peg$currPos | 0;
   let peg$savedPos = peg$currPos;
   const peg$posDetailsCache = [{ line: 1, column: 1 }];
   let peg$maxFailPos = peg$currPos;
   let peg$maxFailExpected = options.peg$maxFailExpected || [];
   let peg$silentFails = options.peg$silentFails | 0;
-
-  let peg$resultsCache = {};
 
   let peg$result;
 
@@ -554,15 +523,6 @@ function peg$parse(input, options) {
   function peg$parsestart() {
     let s0, s1, s2;
 
-    const key = peg$currPos * 68 + 0;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parseline();
@@ -574,22 +534,11 @@ function peg$parse(input, options) {
     s1 = peg$f0();
     s0 = s1;
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parseline() {
     let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 1;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -606,11 +555,9 @@ function peg$parse(input, options) {
         s3.push(s4);
         s4 = peg$parseS();
       }
-      s4 = [];
-      s5 = peg$parsecomment();
-      while (s5 !== peg$FAILED) {
-        s4.push(s5);
-        s5 = peg$parsecomment();
+      s4 = peg$parsecomment();
+      if (s4 === peg$FAILED) {
+        s4 = null;
       }
       s5 = [];
       s6 = peg$parseNL();
@@ -678,50 +625,25 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parseexpression() {
     let s0;
 
-    const key = peg$currPos * 68 + 2;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$parsecomment();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsepath();
+      s0 = peg$parsetable_or_array_path();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsetablearray();
-        if (s0 === peg$FAILED) {
-          s0 = peg$parseassignment();
-        }
+        s0 = peg$parseassignment();
       }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsecomment() {
-    let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 3;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 35) {
@@ -733,73 +655,21 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$currPos;
-      peg$silentFails++;
-      s5 = peg$parseNL();
-      if (s5 === peg$FAILED) {
-        s5 = peg$parseEOF();
-      }
-      peg$silentFails--;
-      if (s5 === peg$FAILED) {
-        s4 = undefined;
+      s3 = input.charAt(peg$currPos);
+      if (peg$r0.test(s3)) {
+        peg$currPos++;
       } else {
-        peg$currPos = s4;
-        s4 = peg$FAILED;
-      }
-      if (s4 !== peg$FAILED) {
-        if (input.length > peg$currPos) {
-          s5 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
-        }
-        if (s5 !== peg$FAILED) {
-          peg$savedPos = s3;
-          s3 = peg$f1(s5);
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
         s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e1); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$currPos;
-        peg$silentFails++;
-        s5 = peg$parseNL();
-        if (s5 === peg$FAILED) {
-          s5 = peg$parseEOF();
-        }
-        peg$silentFails--;
-        if (s5 === peg$FAILED) {
-          s4 = undefined;
+        s3 = input.charAt(peg$currPos);
+        if (peg$r0.test(s3)) {
+          peg$currPos++;
         } else {
-          peg$currPos = s4;
-          s4 = peg$FAILED;
-        }
-        if (s4 !== peg$FAILED) {
-          if (input.length > peg$currPos) {
-            s5 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e1); }
-          }
-          if (s5 !== peg$FAILED) {
-            peg$savedPos = s3;
-            s3 = peg$f1(s5);
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
           s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e1); }
         }
       }
       s1 = [s1, s2];
@@ -809,85 +679,11 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
-  function peg$parsepath() {
-    let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 4;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c1;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e2); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseS();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseS();
-      }
-      s3 = peg$parsetable_key();
-      if (s3 !== peg$FAILED) {
-        s4 = [];
-        s5 = peg$parseS();
-        while (s5 !== peg$FAILED) {
-          s4.push(s5);
-          s5 = peg$parseS();
-        }
-        if (input.charCodeAt(peg$currPos) === 93) {
-          s5 = peg$c2;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e3); }
-        }
-        if (s5 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f2(s3);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsetablearray() {
+  function peg$parsetable_or_array_path() {
     let s0, s1, s2, s3, s4, s5, s6, s7;
-
-    const key = peg$currPos * 68 + 5;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
@@ -937,7 +733,7 @@ function peg$parse(input, options) {
             }
             if (s7 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f3(s4);
+              s0 = peg$f1(s4);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -958,23 +754,59 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 91) {
+        s1 = peg$c1;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parseS();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseS();
+        }
+        s3 = peg$parsetable_key();
+        if (s3 !== peg$FAILED) {
+          s4 = [];
+          s5 = peg$parseS();
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$parseS();
+          }
+          if (input.charCodeAt(peg$currPos) === 93) {
+            s5 = peg$c2;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e3); }
+          }
+          if (s5 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f2(s3);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
 
     return s0;
   }
 
   function peg$parsetable_key() {
     let s0, s1, s2;
-
-    const key = peg$currPos * 68 + 6;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -991,7 +823,7 @@ function peg$parse(input, options) {
       s2 = peg$parsetable_key_part();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f4(s1, s2);
+        s0 = peg$f3(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1005,27 +837,16 @@ function peg$parse(input, options) {
       s1 = peg$parsetable_key_part();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f5(s1);
+        s1 = peg$f4(s1);
       }
       s0 = s1;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsetable_key_part() {
     let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 7;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -1034,7 +855,7 @@ function peg$parse(input, options) {
       s1.push(s2);
       s2 = peg$parseS();
     }
-    s2 = peg$parsekey();
+    s2 = peg$parsesimple_key();
     if (s2 !== peg$FAILED) {
       s3 = [];
       s4 = peg$parseS();
@@ -1043,51 +864,17 @@ function peg$parse(input, options) {
         s4 = peg$parseS();
       }
       peg$savedPos = s0;
-      s0 = peg$f6(s2);
+      s0 = peg$f5(s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parseS();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parseS();
-      }
-      s2 = peg$parsequoted_key();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseS();
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          s4 = peg$parseS();
-        }
-        peg$savedPos = s0;
-        s0 = peg$f7(s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsedot_ended_table_key_part() {
-    let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 8;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = [];
@@ -1096,7 +883,7 @@ function peg$parse(input, options) {
       s1.push(s2);
       s2 = peg$parseS();
     }
-    s2 = peg$parsekey();
+    s2 = peg$parsesimple_key();
     if (s2 !== peg$FAILED) {
       s3 = [];
       s4 = peg$parseS();
@@ -1112,14 +899,8 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e4); }
       }
       if (s4 !== peg$FAILED) {
-        s5 = [];
-        s6 = peg$parseS();
-        while (s6 !== peg$FAILED) {
-          s5.push(s6);
-          s6 = peg$parseS();
-        }
         peg$savedPos = s0;
-        s0 = peg$f8(s2);
+        s0 = peg$f6(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1128,64 +909,12 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parseS();
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parseS();
-      }
-      s2 = peg$parsequoted_key();
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseS();
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          s4 = peg$parseS();
-        }
-        if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c3;
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e4); }
-        }
-        if (s4 !== peg$FAILED) {
-          s5 = [];
-          s6 = peg$parseS();
-          while (s6 !== peg$FAILED) {
-            s5.push(s6);
-            s6 = peg$parseS();
-          }
-          peg$savedPos = s0;
-          s0 = peg$f9(s2);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parseassignment() {
     let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 9;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = peg$parseinline_key();
@@ -1213,7 +942,7 @@ function peg$parse(input, options) {
         s5 = peg$parsevalue();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f10(s1, s5);
+          s0 = peg$f7(s1, s5);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1227,22 +956,11 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsekey() {
     let s0, s1, s2;
-
-    const key = peg$currPos * 68 + 10;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -1256,12 +974,10 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f11(s1);
+      s0 = input.substring(s0, peg$currPos);
+    } else {
+      s0 = s1;
     }
-    s0 = s1;
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -1269,20 +985,11 @@ function peg$parse(input, options) {
   function peg$parsequoted_key() {
     let s0, s1;
 
-    const key = peg$currPos * 68 + 11;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     s1 = peg$parsedouble_quoted_single_line_string();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f12(s1);
+      s1 = peg$f8(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1290,12 +997,10 @@ function peg$parse(input, options) {
       s1 = peg$parsesingle_quoted_single_line_string();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f13(s1);
+        s1 = peg$f9(s1);
       }
       s0 = s1;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -1303,51 +1008,93 @@ function peg$parse(input, options) {
   function peg$parsevalue() {
     let s0;
 
-    const key = peg$currPos * 68 + 12;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$parsestring();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsedatetime();
+      s0 = peg$parsenumber_or_date();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsefloat();
+        s0 = peg$parseboolean();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseinteger();
+          s0 = peg$parsearray();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseboolean();
-            if (s0 === peg$FAILED) {
-              s0 = peg$parsearray();
-              if (s0 === peg$FAILED) {
-                s0 = peg$parseinline_table();
-              }
-            }
+            s0 = peg$parseinline_table();
           }
         }
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+    return s0;
+  }
+
+  function peg$parsenumber_or_date() {
+    let s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = input.charAt(peg$currPos);
+    if (peg$r1.test(s1)) {
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e6); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (input.substr(peg$currPos, 3) === peg$c5) {
+      s2 = peg$c5;
+      peg$currPos += 3;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e7); }
+    }
+    if (s2 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s0 = peg$f10(s1);
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = input.charAt(peg$currPos);
+      if (peg$r1.test(s1)) {
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e6); }
+      }
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (input.substr(peg$currPos, 3) === peg$c6) {
+        s2 = peg$c6;
+        peg$currPos += 3;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e8); }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f11(s1);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsedatetime();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parsefloat();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseinteger();
+          }
+        }
+      }
+    }
 
     return s0;
   }
 
   function peg$parsestring() {
     let s0;
-
-    const key = peg$currPos * 68 + 13;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$parsedouble_quoted_multiline_string();
     if (s0 === peg$FAILED) {
@@ -1360,30 +1107,19 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsedouble_quoted_multiline_string() {
     let s0, s1, s2, s3, s4;
 
-    const key = peg$currPos * 68 + 14;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c5) {
-      s1 = peg$c5;
+    if (input.substr(peg$currPos, 3) === peg$c7) {
+      s1 = peg$c7;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e6); }
+      if (peg$silentFails === 0) { peg$fail(peg$e9); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseNL();
@@ -1391,12 +1127,91 @@ function peg$parse(input, options) {
         s2 = null;
       }
       s3 = peg$parsemlb_body();
-      if (input.substr(peg$currPos, 3) === peg$c5) {
-        s4 = peg$c5;
+      if (input.substr(peg$currPos, 3) === peg$c7) {
+        s4 = peg$c7;
         peg$currPos += 3;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e6); }
+        if (peg$silentFails === 0) { peg$fail(peg$e9); }
+      }
+      if (s4 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f12(s3);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsedouble_quoted_single_line_string() {
+    let s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 34) {
+      s1 = peg$c8;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e10); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parsestring_char();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parsestring_char();
+      }
+      if (input.charCodeAt(peg$currPos) === 34) {
+        s3 = peg$c8;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e10); }
+      }
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f13(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsesingle_quoted_multiline_string() {
+    let s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c9) {
+      s1 = peg$c9;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e11); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseNL();
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      s3 = peg$parsemll_body();
+      if (input.substr(peg$currPos, 3) === peg$c9) {
+        s4 = peg$c9;
+        peg$currPos += 3;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e11); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -1410,44 +1225,33 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
-  function peg$parsedouble_quoted_single_line_string() {
+  function peg$parsesingle_quoted_single_line_string() {
     let s0, s1, s2, s3;
 
-    const key = peg$currPos * 68 + 15;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c6;
+    if (input.charCodeAt(peg$currPos) === 39) {
+      s1 = peg$c10;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e7); }
+      if (peg$silentFails === 0) { peg$fail(peg$e12); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parsestring_char();
+      s3 = peg$parseliteral_char();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parsestring_char();
+        s3 = peg$parseliteral_char();
       }
-      if (input.charCodeAt(peg$currPos) === 34) {
-        s3 = peg$c6;
+      if (input.charCodeAt(peg$currPos) === 39) {
+        s3 = peg$c10;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e7); }
+        if (peg$silentFails === 0) { peg$fail(peg$e12); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -1461,123 +1265,11 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsesingle_quoted_multiline_string() {
-    let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 16;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c7) {
-      s1 = peg$c7;
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e8); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseNL();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      s3 = peg$parsemll_body();
-      if (input.substr(peg$currPos, 3) === peg$c7) {
-        s4 = peg$c7;
-        peg$currPos += 3;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e8); }
-      }
-      if (s4 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f16(s3);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsesingle_quoted_single_line_string() {
-    let s0, s1, s2, s3;
-
-    const key = peg$currPos * 68 + 17;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c8;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e9); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseliteral_char();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseliteral_char();
-      }
-      if (input.charCodeAt(peg$currPos) === 39) {
-        s3 = peg$c8;
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e9); }
-      }
-      if (s3 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f17(s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsemlb_body() {
     let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 18;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -1643,9 +1335,7 @@ function peg$parse(input, options) {
       s3 = null;
     }
     peg$savedPos = s0;
-    s0 = peg$f18(s1, s2, s3);
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+    s0 = peg$f16(s1, s2, s3);
 
     return s0;
   }
@@ -1653,26 +1343,17 @@ function peg$parse(input, options) {
   function peg$parsemlb_content() {
     let s0, s1, s2;
 
-    const key = peg$currPos * 68 + 19;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$parseESCAPED();
     if (s0 === peg$FAILED) {
       s0 = peg$parsemlb_escaped_newline();
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c9;
+          s1 = peg$c11;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e10); }
+          if (peg$silentFails === 0) { peg$fail(peg$e13); }
         }
         if (s1 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1680,11 +1361,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e1); }
+            if (peg$silentFails === 0) { peg$fail(peg$e14); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f19();
+            s0 = peg$f17();
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1695,61 +1376,51 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c10) {
-            s1 = peg$c10;
+          if (input.substr(peg$currPos, 2) === peg$c12) {
+            s1 = peg$c12;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e11); }
+            if (peg$silentFails === 0) { peg$fail(peg$e15); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$f20();
+            s1 = peg$f18();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$currPos;
-            peg$silentFails++;
-            if (input.charCodeAt(peg$currPos) === 34) {
-              s2 = peg$c6;
+            s1 = [];
+            s2 = input.charAt(peg$currPos);
+            if (peg$r2.test(s2)) {
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e16); }
             }
-            peg$silentFails--;
-            if (s2 === peg$FAILED) {
-              s1 = undefined;
+            if (s2 !== peg$FAILED) {
+              while (s2 !== peg$FAILED) {
+                s1.push(s2);
+                s2 = input.charAt(peg$currPos);
+                if (peg$r2.test(s2)) {
+                  peg$currPos++;
+                } else {
+                  s2 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$e16); }
+                }
+              }
             } else {
-              peg$currPos = s1;
               s1 = peg$FAILED;
             }
             if (s1 !== peg$FAILED) {
-              if (input.length > peg$currPos) {
-                s2 = input.charAt(peg$currPos);
-                peg$currPos++;
-              } else {
-                s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e1); }
-              }
-              if (s2 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s0 = peg$f21(s2);
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              s0 = input.substring(s0, peg$currPos);
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              s0 = s1;
             }
           }
         }
       }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -1757,22 +1428,13 @@ function peg$parse(input, options) {
   function peg$parsemlb_escaped_newline() {
     let s0, s1, s2, s3, s4, s5;
 
-    const key = peg$currPos * 68 + 20;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c9;
+      s1 = peg$c11;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e10); }
+      if (peg$silentFails === 0) { peg$fail(peg$e13); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1790,7 +1452,7 @@ function peg$parse(input, options) {
           s5 = peg$parseNLS();
         }
         peg$savedPos = s0;
-        s0 = peg$f22();
+        s0 = peg$f19();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1800,40 +1462,29 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsemlb_quotes() {
     let s0, s1, s2, s3;
 
-    const key = peg$currPos * 68 + 21;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c11) {
-      s1 = peg$c11;
+    if (input.substr(peg$currPos, 2) === peg$c13) {
+      s1 = peg$c13;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e12); }
+      if (peg$silentFails === 0) { peg$fail(peg$e17); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s3 = peg$c6;
+        s3 = peg$c8;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e7); }
+        if (peg$silentFails === 0) { peg$fail(peg$e10); }
       }
       peg$silentFails--;
       if (s3 === peg$FAILED) {
@@ -1844,7 +1495,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f23();
+        s0 = peg$f20();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1856,21 +1507,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c6;
+        s1 = peg$c8;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e7); }
+        if (peg$silentFails === 0) { peg$fail(peg$e10); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c6;
+          s3 = peg$c8;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e7); }
+          if (peg$silentFails === 0) { peg$fail(peg$e10); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -1881,7 +1532,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f24();
+          s0 = peg$f21();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1892,40 +1543,29 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsemlb_trailing() {
     let s0, s1, s2, s3;
 
-    const key = peg$currPos * 68 + 22;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c11) {
-      s1 = peg$c11;
+    if (input.substr(peg$currPos, 2) === peg$c13) {
+      s1 = peg$c13;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e12); }
+      if (peg$silentFails === 0) { peg$fail(peg$e17); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 3) === peg$c5) {
-        s3 = peg$c5;
+      if (input.substr(peg$currPos, 3) === peg$c7) {
+        s3 = peg$c7;
         peg$currPos += 3;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e6); }
+        if (peg$silentFails === 0) { peg$fail(peg$e9); }
       }
       peg$silentFails--;
       if (s3 !== peg$FAILED) {
@@ -1936,7 +1576,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f25();
+        s0 = peg$f22();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1948,21 +1588,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c6;
+        s1 = peg$c8;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e7); }
+        if (peg$silentFails === 0) { peg$fail(peg$e10); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 3) === peg$c5) {
-          s3 = peg$c5;
+        if (input.substr(peg$currPos, 3) === peg$c7) {
+          s3 = peg$c7;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e9); }
         }
         peg$silentFails--;
         if (s3 !== peg$FAILED) {
@@ -1973,7 +1613,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f26();
+          s0 = peg$f23();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1984,22 +1624,11 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsemll_body() {
     let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 23;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -2065,9 +1694,7 @@ function peg$parse(input, options) {
       s3 = null;
     }
     peg$savedPos = s0;
-    s0 = peg$f27(s1, s2, s3);
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+    s0 = peg$f24(s1, s2, s3);
 
     return s0;
   }
@@ -2075,68 +1702,49 @@ function peg$parse(input, options) {
   function peg$parsemll_content() {
     let s0, s1, s2;
 
-    const key = peg$currPos * 68 + 24;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c10) {
-      s1 = peg$c10;
+    if (input.substr(peg$currPos, 2) === peg$c12) {
+      s1 = peg$c12;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e11); }
+      if (peg$silentFails === 0) { peg$fail(peg$e15); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f28();
+      s1 = peg$f25();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c8;
+      s1 = [];
+      s2 = input.charAt(peg$currPos);
+      if (peg$r3.test(s2)) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e9); }
+        if (peg$silentFails === 0) { peg$fail(peg$e18); }
       }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = undefined;
+      if (s2 !== peg$FAILED) {
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = input.charAt(peg$currPos);
+          if (peg$r3.test(s2)) {
+            peg$currPos++;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e18); }
+          }
+        }
       } else {
-        peg$currPos = s1;
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
-        if (input.length > peg$currPos) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f29(s2);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+        s0 = input.substring(s0, peg$currPos);
       } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+        s0 = s1;
       }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -2144,32 +1752,23 @@ function peg$parse(input, options) {
   function peg$parsemll_quotes() {
     let s0, s1, s2, s3;
 
-    const key = peg$currPos * 68 + 25;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c12) {
-      s1 = peg$c12;
+    if (input.substr(peg$currPos, 2) === peg$c14) {
+      s1 = peg$c14;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e13); }
+      if (peg$silentFails === 0) { peg$fail(peg$e19); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s3 = peg$c8;
+        s3 = peg$c10;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e9); }
+        if (peg$silentFails === 0) { peg$fail(peg$e12); }
       }
       peg$silentFails--;
       if (s3 === peg$FAILED) {
@@ -2180,7 +1779,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f30();
+        s0 = peg$f26();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2192,21 +1791,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c8;
+        s1 = peg$c10;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e9); }
+        if (peg$silentFails === 0) { peg$fail(peg$e12); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c8;
+          s3 = peg$c10;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e9); }
+          if (peg$silentFails === 0) { peg$fail(peg$e12); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -2217,7 +1816,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f31();
+          s0 = peg$f27();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2228,40 +1827,29 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsemll_trailing() {
     let s0, s1, s2, s3;
 
-    const key = peg$currPos * 68 + 26;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c12) {
-      s1 = peg$c12;
+    if (input.substr(peg$currPos, 2) === peg$c14) {
+      s1 = peg$c14;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e13); }
+      if (peg$silentFails === 0) { peg$fail(peg$e19); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 3) === peg$c7) {
-        s3 = peg$c7;
+      if (input.substr(peg$currPos, 3) === peg$c9) {
+        s3 = peg$c9;
         peg$currPos += 3;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e8); }
+        if (peg$silentFails === 0) { peg$fail(peg$e11); }
       }
       peg$silentFails--;
       if (s3 !== peg$FAILED) {
@@ -2272,7 +1860,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f32();
+        s0 = peg$f28();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2284,21 +1872,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c8;
+        s1 = peg$c10;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e9); }
+        if (peg$silentFails === 0) { peg$fail(peg$e12); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 3) === peg$c7) {
-          s3 = peg$c7;
+        if (input.substr(peg$currPos, 3) === peg$c9) {
+          s3 = peg$c9;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e8); }
+          if (peg$silentFails === 0) { peg$fail(peg$e11); }
         }
         peg$silentFails--;
         if (s3 !== peg$FAILED) {
@@ -2309,7 +1897,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f33();
+          s0 = peg$f29();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2320,32 +1908,21 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsestring_char() {
-    let s0, s1, s2, s3;
-
-    const key = peg$currPos * 68 + 27;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2;
 
     s0 = peg$parseESCAPED();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c9;
+        s1 = peg$c11;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e10); }
+        if (peg$silentFails === 0) { peg$fail(peg$e13); }
       }
       if (s1 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -2353,11 +1930,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
+          if (peg$silentFails === 0) { peg$fail(peg$e14); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f34();
+          s0 = peg$f30();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2368,135 +1945,70 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$currPos;
-        peg$silentFails++;
-        if (input.charCodeAt(peg$currPos) === 34) {
-          s2 = peg$c6;
+        s1 = [];
+        s2 = input.charAt(peg$currPos);
+        if (peg$r4.test(s2)) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e7); }
+          if (peg$silentFails === 0) { peg$fail(peg$e20); }
         }
-        peg$silentFails--;
-        if (s2 === peg$FAILED) {
-          s1 = undefined;
+        if (s2 !== peg$FAILED) {
+          while (s2 !== peg$FAILED) {
+            s1.push(s2);
+            s2 = input.charAt(peg$currPos);
+            if (peg$r4.test(s2)) {
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$e20); }
+            }
+          }
         } else {
-          peg$currPos = s1;
           s1 = peg$FAILED;
         }
         if (s1 !== peg$FAILED) {
-          s2 = peg$currPos;
-          peg$silentFails++;
-          s3 = peg$parseNL();
-          if (s3 === peg$FAILED) {
-            s3 = peg$parseEOF();
-          }
-          peg$silentFails--;
-          if (s3 === peg$FAILED) {
-            s2 = undefined;
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
-          }
-          if (s2 !== peg$FAILED) {
-            if (input.length > peg$currPos) {
-              s3 = input.charAt(peg$currPos);
-              peg$currPos++;
-            } else {
-              s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e1); }
-            }
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f35(s3);
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+          s0 = input.substring(s0, peg$currPos);
         } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
+          s0 = s1;
         }
       }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parseliteral_char() {
-    let s0, s1, s2, s3;
-
-    const key = peg$currPos * 68 + 28;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    peg$silentFails++;
-    if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c8;
+    s1 = [];
+    s2 = input.charAt(peg$currPos);
+    if (peg$r5.test(s2)) {
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e9); }
+      if (peg$silentFails === 0) { peg$fail(peg$e21); }
     }
-    peg$silentFails--;
-    if (s2 === peg$FAILED) {
-      s1 = undefined;
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = input.charAt(peg$currPos);
+        if (peg$r5.test(s2)) {
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e21); }
+        }
+      }
     } else {
-      peg$currPos = s1;
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseNL();
-      if (s3 === peg$FAILED) {
-        s3 = peg$parseEOF();
-      }
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = undefined;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        if (input.length > peg$currPos) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f36(s3);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      s0 = input.substring(s0, peg$currPos);
     } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      s0 = s1;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -2504,130 +2016,56 @@ function peg$parse(input, options) {
   function peg$parsefloat() {
     let s0, s1, s2, s3;
 
-    const key = peg$currPos * 68 + 29;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
-    s1 = input.charAt(peg$currPos);
-    if (peg$r0.test(s1)) {
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (input.substr(peg$currPos, 3) === peg$c13) {
-      s2 = peg$c13;
-      peg$currPos += 3;
-    } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e15); }
-    }
-    if (s2 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s0 = peg$f37(s1);
+    s1 = peg$parsefloat_or_int_text();
+    if (s1 !== peg$FAILED) {
+      s2 = input.charAt(peg$currPos);
+      if (peg$r6.test(s2)) {
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e22); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsefloat_exp_text();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s0 = peg$f31(s1, s3);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = input.charAt(peg$currPos);
-      if (peg$r0.test(s1)) {
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e14); }
-      }
-      if (s1 === peg$FAILED) {
-        s1 = null;
-      }
-      if (input.substr(peg$currPos, 3) === peg$c14) {
-        s2 = peg$c14;
-        peg$currPos += 3;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e16); }
-      }
-      if (s2 !== peg$FAILED) {
+      s1 = peg$parsefloat_text();
+      if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f38(s1);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+        s1 = peg$f32(s1);
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsefloat_or_int_text();
-        if (s1 !== peg$FAILED) {
-          s2 = input.charAt(peg$currPos);
-          if (peg$r1.test(s2)) {
-            peg$currPos++;
-          } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e17); }
-          }
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parsefloat_exp_text();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f39(s1, s3);
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          s1 = peg$parsefloat_text();
-          if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$f40(s1);
-          }
-          s0 = s1;
-        }
-      }
+      s0 = s1;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsefloat_text() {
-    let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 30;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = input.charAt(peg$currPos);
-    if (peg$r0.test(s1)) {
+    if (peg$r1.test(s1)) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+      if (peg$silentFails === 0) { peg$fail(peg$e6); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -2642,10 +2080,16 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e4); }
       }
       if (s3 !== peg$FAILED) {
-        s4 = peg$parseDEC_INT();
+        s4 = peg$currPos;
+        s5 = peg$parseDEC_DIGIT_SEQ();
+        if (s5 !== peg$FAILED) {
+          s4 = input.substring(s4, peg$currPos);
+        } else {
+          s4 = s5;
+        }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f41(s1, s2, s4);
+          s0 = peg$f33(s1, s2, s4);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2659,30 +2103,19 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsefloat_or_int_text() {
-    let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 31;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = input.charAt(peg$currPos);
-    if (peg$r0.test(s1)) {
+    if (peg$r1.test(s1)) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+      if (peg$silentFails === 0) { peg$fail(peg$e6); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -2697,10 +2130,16 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e4); }
       }
       if (s3 !== peg$FAILED) {
-        s4 = peg$parseDEC_INT();
+        s4 = peg$currPos;
+        s5 = peg$parseDEC_DIGIT_SEQ();
+        if (s5 !== peg$FAILED) {
+          s4 = input.substring(s4, peg$currPos);
+        } else {
+          s4 = s5;
+        }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f42(s1, s2, s4);
+          s0 = peg$f34(s1, s2, s4);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2716,11 +2155,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = input.charAt(peg$currPos);
-      if (peg$r0.test(s1)) {
+      if (peg$r1.test(s1)) {
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e14); }
+        if (peg$silentFails === 0) { peg$fail(peg$e6); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
@@ -2728,14 +2167,12 @@ function peg$parse(input, options) {
       s2 = peg$parseFLOAT_DEC_INT();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f43(s1, s2);
+        s0 = peg$f35(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -2743,85 +2180,66 @@ function peg$parse(input, options) {
   function peg$parseFLOAT_DEC_INT() {
     let s0, s1;
 
-    const key = peg$currPos * 68 + 32;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 48) {
       s1 = peg$c15;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e18); }
+      if (peg$silentFails === 0) { peg$fail(peg$e23); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f44();
+      s1 = peg$f36();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
-      s0 = peg$parseDEC_INT_NOZERO();
+      s0 = peg$currPos;
+      s1 = peg$parseDEC_INT_NOZERO_SEQ();
+      if (s1 !== peg$FAILED) {
+        s0 = input.substring(s0, peg$currPos);
+      } else {
+        s0 = s1;
+      }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsefloat_exp_text() {
-    let s0, s1, s2;
-
-    const key = peg$currPos * 68 + 33;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = input.charAt(peg$currPos);
-    if (peg$r0.test(s1)) {
+    if (peg$r1.test(s1)) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+      if (peg$silentFails === 0) { peg$fail(peg$e6); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
-    s2 = peg$parseDEC_INT();
+    s2 = peg$currPos;
+    s3 = peg$parseDEC_DIGIT_SEQ();
+    if (s3 !== peg$FAILED) {
+      s2 = input.substring(s2, peg$currPos);
+    } else {
+      s2 = s3;
+    }
     if (s2 !== peg$FAILED) {
       peg$savedPos = s0;
-      s0 = peg$f45(s1, s2);
+      s0 = peg$f37(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parseinteger() {
-    let s0, s1, s2;
-
-    const key = peg$currPos * 68 + 34;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2) === peg$c16) {
@@ -2829,13 +2247,19 @@ function peg$parse(input, options) {
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e19); }
+      if (peg$silentFails === 0) { peg$fail(peg$e24); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseHEX_INT();
+      s2 = peg$currPos;
+      s3 = peg$parseHEX_DIGIT_SEQ();
+      if (s3 !== peg$FAILED) {
+        s2 = input.substring(s2, peg$currPos);
+      } else {
+        s2 = s3;
+      }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f46(s2);
+        s0 = peg$f38(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2851,13 +2275,19 @@ function peg$parse(input, options) {
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e20); }
+        if (peg$silentFails === 0) { peg$fail(peg$e25); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseOCT_INT();
+        s2 = peg$currPos;
+        s3 = peg$parseOCT_DIGIT_SEQ();
+        if (s3 !== peg$FAILED) {
+          s2 = input.substring(s2, peg$currPos);
+        } else {
+          s2 = s3;
+        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f47(s2);
+          s0 = peg$f39(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2873,13 +2303,19 @@ function peg$parse(input, options) {
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e21); }
+          if (peg$silentFails === 0) { peg$fail(peg$e26); }
         }
         if (s1 !== peg$FAILED) {
-          s2 = peg$parseBIN_INT();
+          s2 = peg$currPos;
+          s3 = peg$parseBIN_DIGIT_SEQ();
+          if (s3 !== peg$FAILED) {
+            s2 = input.substring(s2, peg$currPos);
+          } else {
+            s2 = s3;
+          }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f48(s2);
+            s0 = peg$f40(s2);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2893,14 +2329,12 @@ function peg$parse(input, options) {
           s1 = peg$parsedec_integer_text();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$f49(s1);
+            s1 = peg$f41(s1);
           }
           s0 = s1;
         }
       }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -2908,22 +2342,13 @@ function peg$parse(input, options) {
   function peg$parsedec_integer_text() {
     let s0, s1, s2, s3, s4, s5;
 
-    const key = peg$currPos * 68 + 35;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     s1 = input.charAt(peg$currPos);
-    if (peg$r0.test(s1)) {
+    if (peg$r1.test(s1)) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+      if (peg$silentFails === 0) { peg$fail(peg$e6); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -2933,17 +2358,17 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e18); }
+      if (peg$silentFails === 0) { peg$fail(peg$e23); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$currPos;
       peg$silentFails++;
       s4 = input.charAt(peg$currPos);
-      if (peg$r2.test(s4)) {
+      if (peg$r7.test(s4)) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e22); }
+        if (peg$silentFails === 0) { peg$fail(peg$e27); }
       }
       peg$silentFails--;
       if (s4 === peg$FAILED) {
@@ -2971,7 +2396,7 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f50(s1);
+          s0 = peg$f42(s1);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2987,16 +2412,22 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = input.charAt(peg$currPos);
-      if (peg$r0.test(s1)) {
+      if (peg$r1.test(s1)) {
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e14); }
+        if (peg$silentFails === 0) { peg$fail(peg$e6); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
-      s2 = peg$parseDEC_INT_NOZERO();
+      s2 = peg$currPos;
+      s3 = peg$parseDEC_INT_NOZERO_SEQ();
+      if (s3 !== peg$FAILED) {
+        s2 = input.substring(s2, peg$currPos);
+      } else {
+        s2 = s3;
+      }
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
         peg$silentFails++;
@@ -3016,7 +2447,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f51(s1, s2);
+          s0 = peg$f43(s1, s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3027,370 +2458,11 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
-  function peg$parseDEC_INT_NOZERO() {
+  function peg$parseDEC_INT_NOZERO_SEQ() {
     let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 36;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = input.charAt(peg$currPos);
-    if (peg$r3.test(s1)) {
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e23); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = input.charAt(peg$currPos);
-      if (peg$r4.test(s4)) {
-        peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e24); }
-      }
-      if (s4 === peg$FAILED) {
-        s4 = null;
-      }
-      s5 = input.charAt(peg$currPos);
-      if (peg$r5.test(s5)) {
-        peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e25); }
-      }
-      if (s5 !== peg$FAILED) {
-        s4 = [s4, s5];
-        s3 = s4;
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = input.charAt(peg$currPos);
-        if (peg$r4.test(s4)) {
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e24); }
-        }
-        if (s4 === peg$FAILED) {
-          s4 = null;
-        }
-        s5 = input.charAt(peg$currPos);
-        if (peg$r5.test(s5)) {
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e25); }
-        }
-        if (s5 !== peg$FAILED) {
-          s4 = [s4, s5];
-          s3 = s4;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      peg$savedPos = s0;
-      s0 = peg$f52(s1, s2);
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseDEC_INT() {
-    let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 37;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = input.charAt(peg$currPos);
-    if (peg$r5.test(s1)) {
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e25); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = input.charAt(peg$currPos);
-      if (peg$r4.test(s4)) {
-        peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e24); }
-      }
-      if (s4 === peg$FAILED) {
-        s4 = null;
-      }
-      s5 = input.charAt(peg$currPos);
-      if (peg$r5.test(s5)) {
-        peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e25); }
-      }
-      if (s5 !== peg$FAILED) {
-        s4 = [s4, s5];
-        s3 = s4;
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = input.charAt(peg$currPos);
-        if (peg$r4.test(s4)) {
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e24); }
-        }
-        if (s4 === peg$FAILED) {
-          s4 = null;
-        }
-        s5 = input.charAt(peg$currPos);
-        if (peg$r5.test(s5)) {
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e25); }
-        }
-        if (s5 !== peg$FAILED) {
-          s4 = [s4, s5];
-          s3 = s4;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      peg$savedPos = s0;
-      s0 = peg$f53(s1, s2);
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseHEX_INT() {
-    let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 38;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = input.charAt(peg$currPos);
-    if (peg$r6.test(s1)) {
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e26); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = input.charAt(peg$currPos);
-      if (peg$r4.test(s4)) {
-        peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e24); }
-      }
-      if (s4 === peg$FAILED) {
-        s4 = null;
-      }
-      s5 = input.charAt(peg$currPos);
-      if (peg$r6.test(s5)) {
-        peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e26); }
-      }
-      if (s5 !== peg$FAILED) {
-        s4 = [s4, s5];
-        s3 = s4;
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = input.charAt(peg$currPos);
-        if (peg$r4.test(s4)) {
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e24); }
-        }
-        if (s4 === peg$FAILED) {
-          s4 = null;
-        }
-        s5 = input.charAt(peg$currPos);
-        if (peg$r6.test(s5)) {
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e26); }
-        }
-        if (s5 !== peg$FAILED) {
-          s4 = [s4, s5];
-          s3 = s4;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      peg$savedPos = s0;
-      s0 = peg$f54(s1, s2);
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseOCT_INT() {
-    let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 39;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = input.charAt(peg$currPos);
-    if (peg$r7.test(s1)) {
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e27); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = input.charAt(peg$currPos);
-      if (peg$r4.test(s4)) {
-        peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e24); }
-      }
-      if (s4 === peg$FAILED) {
-        s4 = null;
-      }
-      s5 = input.charAt(peg$currPos);
-      if (peg$r7.test(s5)) {
-        peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e27); }
-      }
-      if (s5 !== peg$FAILED) {
-        s4 = [s4, s5];
-        s3 = s4;
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = input.charAt(peg$currPos);
-        if (peg$r4.test(s4)) {
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e24); }
-        }
-        if (s4 === peg$FAILED) {
-          s4 = null;
-        }
-        s5 = input.charAt(peg$currPos);
-        if (peg$r7.test(s5)) {
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e27); }
-        }
-        if (s5 !== peg$FAILED) {
-          s4 = [s4, s5];
-          s3 = s4;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      peg$savedPos = s0;
-      s0 = peg$f55(s1, s2);
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseBIN_INT() {
-    let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 40;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = input.charAt(peg$currPos);
@@ -3404,21 +2476,21 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       s4 = input.charAt(peg$currPos);
-      if (peg$r4.test(s4)) {
+      if (peg$r9.test(s4)) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e24); }
+        if (peg$silentFails === 0) { peg$fail(peg$e29); }
       }
       if (s4 === peg$FAILED) {
         s4 = null;
       }
       s5 = input.charAt(peg$currPos);
-      if (peg$r8.test(s5)) {
+      if (peg$r10.test(s5)) {
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e28); }
+        if (peg$silentFails === 0) { peg$fail(peg$e30); }
       }
       if (s5 !== peg$FAILED) {
         s4 = [s4, s5];
@@ -3431,21 +2503,21 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = input.charAt(peg$currPos);
-        if (peg$r4.test(s4)) {
+        if (peg$r9.test(s4)) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e24); }
+          if (peg$silentFails === 0) { peg$fail(peg$e29); }
         }
         if (s4 === peg$FAILED) {
           s4 = null;
         }
         s5 = input.charAt(peg$currPos);
-        if (peg$r8.test(s5)) {
+        if (peg$r10.test(s5)) {
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e28); }
+          if (peg$silentFails === 0) { peg$fail(peg$e30); }
         }
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -3455,14 +2527,316 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      peg$savedPos = s0;
-      s0 = peg$f56(s1, s2);
+      s1 = [s1, s2];
+      s0 = s1;
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+    return s0;
+  }
+
+  function peg$parseDEC_DIGIT_SEQ() {
+    let s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = input.charAt(peg$currPos);
+    if (peg$r10.test(s1)) {
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e30); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = input.charAt(peg$currPos);
+      if (peg$r9.test(s4)) {
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      }
+      if (s4 === peg$FAILED) {
+        s4 = null;
+      }
+      s5 = input.charAt(peg$currPos);
+      if (peg$r10.test(s5)) {
+        peg$currPos++;
+      } else {
+        s5 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e30); }
+      }
+      if (s5 !== peg$FAILED) {
+        s4 = [s4, s5];
+        s3 = s4;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = input.charAt(peg$currPos);
+        if (peg$r9.test(s4)) {
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e29); }
+        }
+        if (s4 === peg$FAILED) {
+          s4 = null;
+        }
+        s5 = input.charAt(peg$currPos);
+        if (peg$r10.test(s5)) {
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e30); }
+        }
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      s1 = [s1, s2];
+      s0 = s1;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseHEX_DIGIT_SEQ() {
+    let s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = input.charAt(peg$currPos);
+    if (peg$r11.test(s1)) {
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e31); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = input.charAt(peg$currPos);
+      if (peg$r9.test(s4)) {
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      }
+      if (s4 === peg$FAILED) {
+        s4 = null;
+      }
+      s5 = input.charAt(peg$currPos);
+      if (peg$r11.test(s5)) {
+        peg$currPos++;
+      } else {
+        s5 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+      }
+      if (s5 !== peg$FAILED) {
+        s4 = [s4, s5];
+        s3 = s4;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = input.charAt(peg$currPos);
+        if (peg$r9.test(s4)) {
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e29); }
+        }
+        if (s4 === peg$FAILED) {
+          s4 = null;
+        }
+        s5 = input.charAt(peg$currPos);
+        if (peg$r11.test(s5)) {
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e31); }
+        }
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      s1 = [s1, s2];
+      s0 = s1;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseOCT_DIGIT_SEQ() {
+    let s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = input.charAt(peg$currPos);
+    if (peg$r12.test(s1)) {
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = input.charAt(peg$currPos);
+      if (peg$r9.test(s4)) {
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      }
+      if (s4 === peg$FAILED) {
+        s4 = null;
+      }
+      s5 = input.charAt(peg$currPos);
+      if (peg$r12.test(s5)) {
+        peg$currPos++;
+      } else {
+        s5 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      }
+      if (s5 !== peg$FAILED) {
+        s4 = [s4, s5];
+        s3 = s4;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = input.charAt(peg$currPos);
+        if (peg$r9.test(s4)) {
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e29); }
+        }
+        if (s4 === peg$FAILED) {
+          s4 = null;
+        }
+        s5 = input.charAt(peg$currPos);
+        if (peg$r12.test(s5)) {
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e32); }
+        }
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      s1 = [s1, s2];
+      s0 = s1;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseBIN_DIGIT_SEQ() {
+    let s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = input.charAt(peg$currPos);
+    if (peg$r13.test(s1)) {
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e33); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = input.charAt(peg$currPos);
+      if (peg$r9.test(s4)) {
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      }
+      if (s4 === peg$FAILED) {
+        s4 = null;
+      }
+      s5 = input.charAt(peg$currPos);
+      if (peg$r13.test(s5)) {
+        peg$currPos++;
+      } else {
+        s5 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e33); }
+      }
+      if (s5 !== peg$FAILED) {
+        s4 = [s4, s5];
+        s3 = s4;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = input.charAt(peg$currPos);
+        if (peg$r9.test(s4)) {
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e29); }
+        }
+        if (s4 === peg$FAILED) {
+          s4 = null;
+        }
+        s5 = input.charAt(peg$currPos);
+        if (peg$r13.test(s5)) {
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e33); }
+        }
+        if (s5 !== peg$FAILED) {
+          s4 = [s4, s5];
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      s1 = [s1, s2];
+      s0 = s1;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
 
     return s0;
   }
@@ -3470,26 +2844,17 @@ function peg$parse(input, options) {
   function peg$parseboolean() {
     let s0, s1;
 
-    const key = peg$currPos * 68 + 41;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c19) {
       s1 = peg$c19;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      if (peg$silentFails === 0) { peg$fail(peg$e34); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f57();
+      s1 = peg$f44();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3499,31 +2864,20 @@ function peg$parse(input, options) {
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e30); }
+        if (peg$silentFails === 0) { peg$fail(peg$e35); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f58();
+        s1 = peg$f45();
       }
       s0 = s1;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsearray() {
-    let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 42;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
@@ -3549,7 +2903,7 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f59();
+        s0 = peg$f46();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3568,236 +2922,135 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e2); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsearray_value();
-        if (s2 === peg$FAILED) {
-          s2 = null;
+        s2 = [];
+        s3 = peg$parsearray_sep();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parsearray_sep();
         }
-        if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c2;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e3); }
-        }
+        s3 = peg$parsevalue();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f60(s2);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c1;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e2); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = [];
-          s3 = peg$parsearray_value_list();
-          if (s3 !== peg$FAILED) {
-            while (s3 !== peg$FAILED) {
-              s2.push(s3);
-              s3 = peg$parsearray_value_list();
-            }
-          } else {
-            s2 = peg$FAILED;
+          s4 = [];
+          s5 = peg$currPos;
+          s6 = [];
+          s7 = peg$parsearray_sep();
+          while (s7 !== peg$FAILED) {
+            s6.push(s7);
+            s7 = peg$parsearray_sep();
           }
-          if (s2 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 93) {
-              s3 = peg$c2;
-              peg$currPos++;
-            } else {
-              s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e3); }
-            }
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f61(s2);
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c1;
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s7 = peg$c21;
             peg$currPos++;
           } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e2); }
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e36); }
           }
-          if (s1 !== peg$FAILED) {
-            s2 = [];
-            s3 = peg$parsearray_value_list();
-            if (s3 !== peg$FAILED) {
-              while (s3 !== peg$FAILED) {
-                s2.push(s3);
-                s3 = peg$parsearray_value_list();
-              }
-            } else {
-              s2 = peg$FAILED;
+          if (s7 !== peg$FAILED) {
+            s8 = [];
+            s9 = peg$parsearray_sep();
+            while (s9 !== peg$FAILED) {
+              s8.push(s9);
+              s9 = peg$parsearray_sep();
             }
-            if (s2 !== peg$FAILED) {
-              s3 = peg$parsearray_value();
-              if (s3 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 93) {
-                  s4 = peg$c2;
-                  peg$currPos++;
-                } else {
-                  s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$e3); }
-                }
-                if (s4 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s0 = peg$f62(s2, s3);
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+            s9 = peg$parsevalue();
+            if (s9 !== peg$FAILED) {
+              peg$savedPos = s5;
+              s5 = peg$f47(s3, s9);
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$currPos;
+            s6 = [];
+            s7 = peg$parsearray_sep();
+            while (s7 !== peg$FAILED) {
+              s6.push(s7);
+              s7 = peg$parsearray_sep();
+            }
+            if (input.charCodeAt(peg$currPos) === 44) {
+              s7 = peg$c21;
+              peg$currPos++;
+            } else {
+              s7 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$e36); }
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = [];
+              s9 = peg$parsearray_sep();
+              while (s9 !== peg$FAILED) {
+                s8.push(s9);
+                s9 = peg$parsearray_sep();
+              }
+              s9 = peg$parsevalue();
+              if (s9 !== peg$FAILED) {
+                peg$savedPos = s5;
+                s5 = peg$f47(s3, s9);
               } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+                peg$currPos = s5;
+                s5 = peg$FAILED;
               }
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              peg$currPos = s5;
+              s5 = peg$FAILED;
             }
+          }
+          s5 = [];
+          s6 = peg$parsearray_sep();
+          while (s6 !== peg$FAILED) {
+            s5.push(s6);
+            s6 = peg$parsearray_sep();
+          }
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s6 = peg$c21;
+            peg$currPos++;
+          } else {
+            s6 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e36); }
+          }
+          if (s6 === peg$FAILED) {
+            s6 = null;
+          }
+          s7 = [];
+          s8 = peg$parsearray_sep();
+          while (s8 !== peg$FAILED) {
+            s7.push(s8);
+            s8 = peg$parsearray_sep();
+          }
+          if (input.charCodeAt(peg$currPos) === 93) {
+            s8 = peg$c2;
+            peg$currPos++;
+          } else {
+            s8 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e3); }
+          }
+          if (s8 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f48(s3, s4);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsearray_value() {
-    let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 43;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parsearray_sep();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parsearray_sep();
-    }
-    s2 = peg$parsevalue();
-    if (s2 !== peg$FAILED) {
-      s3 = [];
-      s4 = peg$parsearray_sep();
-      while (s4 !== peg$FAILED) {
-        s3.push(s4);
-        s4 = peg$parsearray_sep();
-      }
-      peg$savedPos = s0;
-      s0 = peg$f63(s2);
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsearray_value_list() {
-    let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 44;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parsearray_sep();
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
-      s2 = peg$parsearray_sep();
-    }
-    s2 = peg$parsevalue();
-    if (s2 !== peg$FAILED) {
-      s3 = [];
-      s4 = peg$parsearray_sep();
-      while (s4 !== peg$FAILED) {
-        s3.push(s4);
-        s4 = peg$parsearray_sep();
-      }
-      if (input.charCodeAt(peg$currPos) === 44) {
-        s4 = peg$c21;
-        peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e31); }
-      }
-      if (s4 !== peg$FAILED) {
-        s5 = [];
-        s6 = peg$parsearray_sep();
-        while (s6 !== peg$FAILED) {
-          s5.push(s6);
-          s6 = peg$parsearray_sep();
-        }
-        peg$savedPos = s0;
-        s0 = peg$f64(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parsearray_sep() {
     let s0;
-
-    const key = peg$currPos * 68 + 45;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$parseS();
     if (s0 === peg$FAILED) {
@@ -3807,22 +3060,11 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parseinline_table() {
-    let s0, s1, s2, s3, s4, s5, s6, s7;
-
-    const key = peg$currPos * 68 + 46;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
@@ -3830,7 +3072,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      if (peg$silentFails === 0) { peg$fail(peg$e37); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -3844,11 +3086,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e33); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f65();
+        s0 = peg$f49();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3864,7 +3106,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e32); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -3873,36 +3115,110 @@ function peg$parse(input, options) {
           s2.push(s3);
           s3 = peg$parseinline_sep();
         }
-        s3 = peg$parseinline_table_entry_list();
+        s3 = peg$parseinline_table_entry();
         if (s3 !== peg$FAILED) {
           s4 = [];
-          s5 = peg$parseinline_sep();
+          s5 = peg$currPos;
+          s6 = [];
+          s7 = peg$parseinline_sep();
+          while (s7 !== peg$FAILED) {
+            s6.push(s7);
+            s7 = peg$parseinline_sep();
+          }
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s7 = peg$c21;
+            peg$currPos++;
+          } else {
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e36); }
+          }
+          if (s7 !== peg$FAILED) {
+            s8 = [];
+            s9 = peg$parseinline_sep();
+            while (s9 !== peg$FAILED) {
+              s8.push(s9);
+              s9 = peg$parseinline_sep();
+            }
+            s9 = peg$parseinline_table_entry();
+            if (s9 !== peg$FAILED) {
+              peg$savedPos = s5;
+              s5 = peg$f50(s3, s9);
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            s5 = peg$parseinline_sep();
-          }
-          s5 = peg$parseinline_table_entry();
-          if (s5 !== peg$FAILED) {
+            s5 = peg$currPos;
             s6 = [];
             s7 = peg$parseinline_sep();
             while (s7 !== peg$FAILED) {
               s6.push(s7);
               s7 = peg$parseinline_sep();
             }
-            if (input.charCodeAt(peg$currPos) === 125) {
-              s7 = peg$c23;
+            if (input.charCodeAt(peg$currPos) === 44) {
+              s7 = peg$c21;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e33); }
+              if (peg$silentFails === 0) { peg$fail(peg$e36); }
             }
             if (s7 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f66(s3, s5);
+              s8 = [];
+              s9 = peg$parseinline_sep();
+              while (s9 !== peg$FAILED) {
+                s8.push(s9);
+                s9 = peg$parseinline_sep();
+              }
+              s9 = peg$parseinline_table_entry();
+              if (s9 !== peg$FAILED) {
+                peg$savedPos = s5;
+                s5 = peg$f50(s3, s9);
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              peg$currPos = s5;
+              s5 = peg$FAILED;
             }
+          }
+          s5 = [];
+          s6 = peg$parseinline_sep();
+          while (s6 !== peg$FAILED) {
+            s5.push(s6);
+            s6 = peg$parseinline_sep();
+          }
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s6 = peg$c21;
+            peg$currPos++;
+          } else {
+            s6 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e36); }
+          }
+          if (s6 === peg$FAILED) {
+            s6 = null;
+          }
+          s7 = [];
+          s8 = peg$parseinline_sep();
+          while (s8 !== peg$FAILED) {
+            s7.push(s8);
+            s8 = peg$parseinline_sep();
+          }
+          if (input.charCodeAt(peg$currPos) === 125) {
+            s8 = peg$c23;
+            peg$currPos++;
+          } else {
+            s8 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e38); }
+          }
+          if (s8 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f51(s3, s4);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -3915,216 +3231,13 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 123) {
-          s1 = peg$c22;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e32); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = [];
-          s3 = peg$parseinline_sep();
-          while (s3 !== peg$FAILED) {
-            s2.push(s3);
-            s3 = peg$parseinline_sep();
-          }
-          s3 = peg$parseinline_table_entry_list();
-          if (s3 !== peg$FAILED) {
-            s4 = [];
-            s5 = peg$parseinline_sep();
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parseinline_sep();
-            }
-            if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c23;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e33); }
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f67(s3);
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 123) {
-            s1 = peg$c22;
-            peg$currPos++;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e32); }
-          }
-          if (s1 !== peg$FAILED) {
-            s2 = [];
-            s3 = peg$parseinline_sep();
-            while (s3 !== peg$FAILED) {
-              s2.push(s3);
-              s3 = peg$parseinline_sep();
-            }
-            s3 = peg$parseinline_table_entry();
-            if (s3 !== peg$FAILED) {
-              s4 = [];
-              s5 = peg$parseinline_sep();
-              while (s5 !== peg$FAILED) {
-                s4.push(s5);
-                s5 = peg$parseinline_sep();
-              }
-              if (input.charCodeAt(peg$currPos) === 125) {
-                s5 = peg$c23;
-                peg$currPos++;
-              } else {
-                s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e33); }
-              }
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s0 = peg$f68(s3);
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        }
-      }
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseinline_table_entry_list() {
-    let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 47;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$currPos;
-    s3 = [];
-    s4 = peg$parseinline_sep();
-    while (s4 !== peg$FAILED) {
-      s3.push(s4);
-      s4 = peg$parseinline_sep();
-    }
-    s4 = peg$parseinline_table_entry();
-    if (s4 !== peg$FAILED) {
-      s5 = [];
-      s6 = peg$parseinline_sep();
-      while (s6 !== peg$FAILED) {
-        s5.push(s6);
-        s6 = peg$parseinline_sep();
-      }
-      if (input.charCodeAt(peg$currPos) === 44) {
-        s6 = peg$c21;
-        peg$currPos++;
-      } else {
-        s6 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e31); }
-      }
-      if (s6 !== peg$FAILED) {
-        peg$savedPos = s2;
-        s2 = peg$f69(s4);
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$currPos;
-        s3 = [];
-        s4 = peg$parseinline_sep();
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          s4 = peg$parseinline_sep();
-        }
-        s4 = peg$parseinline_table_entry();
-        if (s4 !== peg$FAILED) {
-          s5 = [];
-          s6 = peg$parseinline_sep();
-          while (s6 !== peg$FAILED) {
-            s5.push(s6);
-            s6 = peg$parseinline_sep();
-          }
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s6 = peg$c21;
-            peg$currPos++;
-          } else {
-            s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e31); }
-          }
-          if (s6 !== peg$FAILED) {
-            peg$savedPos = s2;
-            s2 = peg$f69(s4);
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-      }
-    } else {
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f70(s1);
-    }
-    s0 = s1;
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parseinline_table_entry() {
     let s0, s1, s2, s3, s4, s5;
-
-    const key = peg$currPos * 68 + 48;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = peg$parseinline_key();
@@ -4152,7 +3265,7 @@ function peg$parse(input, options) {
         s5 = peg$parsevalue();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f71(s1, s5);
+          s0 = peg$f52(s1, s5);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -4166,22 +3279,11 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parseinline_sep() {
     let s0;
-
-    const key = peg$currPos * 68 + 49;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$parseS();
     if (s0 === peg$FAILED) {
@@ -4191,22 +3293,11 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parseinline_key() {
     let s0, s1, s2, s3;
-
-    const key = peg$currPos * 68 + 50;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -4229,7 +3320,7 @@ function peg$parse(input, options) {
       s3 = peg$parsesimple_key();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f72(s1, s3);
+        s0 = peg$f53(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -4243,27 +3334,16 @@ function peg$parse(input, options) {
       s1 = peg$parsesimple_key();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f73(s1);
+        s1 = peg$f54(s1);
       }
       s0 = s1;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parseinline_dot_key_part() {
     let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 51;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = [];
@@ -4289,7 +3369,7 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f74(s2);
+        s0 = peg$f55(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -4298,8 +3378,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -4307,84 +3385,59 @@ function peg$parse(input, options) {
   function peg$parsesimple_key() {
     let s0;
 
-    const key = peg$currPos * 68 + 52;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$parsekey();
     if (s0 === peg$FAILED) {
       s0 = peg$parsequoted_key();
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
   function peg$parsesecfragment() {
-    let s0, s1, s2, s3;
-
-    const key = peg$currPos * 68 + 53;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
+    let s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
+    s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c3;
+      s2 = peg$c3;
       peg$currPos++;
     } else {
-      s1 = peg$FAILED;
+      s2 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e4); }
     }
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseDIGIT();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseDIGIT();
+    if (s2 !== peg$FAILED) {
+      s3 = [];
+      s4 = peg$parseDIGIT();
+      if (s4 !== peg$FAILED) {
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parseDIGIT();
         }
       } else {
-        s2 = peg$FAILED;
+        s3 = peg$FAILED;
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f75(s2);
+      if (s3 !== peg$FAILED) {
+        s2 = [s2, s3];
+        s1 = s2;
       } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+        peg$currPos = s1;
+        s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      peg$currPos = s1;
+      s1 = peg$FAILED;
     }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+    if (s1 !== peg$FAILED) {
+      s0 = input.substring(s0, peg$currPos);
+    } else {
+      s0 = s1;
+    }
 
     return s0;
   }
 
   function peg$parsedate_part() {
     let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
-
-    const key = peg$currPos * 68 + 54;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
 
     s0 = peg$currPos;
     s1 = peg$currPos;
@@ -4401,7 +3454,7 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e34); }
+              if (peg$silentFails === 0) { peg$fail(peg$e39); }
             }
             if (s6 !== peg$FAILED) {
               s7 = peg$parseDIGIT();
@@ -4413,7 +3466,7 @@ function peg$parse(input, options) {
                     peg$currPos++;
                   } else {
                     s9 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e34); }
+                    if (peg$silentFails === 0) { peg$fail(peg$e39); }
                   }
                   if (s9 !== peg$FAILED) {
                     s10 = peg$parseDIGIT();
@@ -4463,12 +3516,10 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f76(s1);
+      s0 = input.substring(s0, peg$currPos);
+    } else {
+      s0 = s1;
     }
-    s0 = s1;
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
@@ -4476,817 +3527,39 @@ function peg$parse(input, options) {
   function peg$parsetime_part() {
     let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    const key = peg$currPos * 68 + 55;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
     s0 = peg$currPos;
     s1 = peg$currPos;
-    s2 = peg$parseDIGIT();
-    if (s2 !== peg$FAILED) {
-      s3 = peg$parseDIGIT();
-      if (s3 !== peg$FAILED) {
+    s2 = peg$currPos;
+    s3 = peg$parseDIGIT();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parseDIGIT();
+      if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s4 = peg$c25;
+          s5 = peg$c25;
           peg$currPos++;
         } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e35); }
-        }
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseDIGIT();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parseDIGIT();
-            if (s6 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 58) {
-                s7 = peg$c25;
-                peg$currPos++;
-              } else {
-                s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e35); }
-              }
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseDIGIT();
-                if (s8 !== peg$FAILED) {
-                  s9 = peg$parseDIGIT();
-                  if (s9 !== peg$FAILED) {
-                    s10 = peg$parsesecfragment();
-                    if (s10 === peg$FAILED) {
-                      s10 = null;
-                    }
-                    s2 = [s2, s3, s4, s5, s6, s7, s8, s9, s10];
-                    s1 = s2;
-                  } else {
-                    peg$currPos = s1;
-                    s1 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s1;
-                  s1 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s1;
-                s1 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s1;
-              s1 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f77(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      s2 = peg$parseDIGIT();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseDIGIT();
-        if (s3 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c25;
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e35); }
-          }
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseDIGIT();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseDIGIT();
-              if (s6 !== peg$FAILED) {
-                s2 = [s2, s3, s4, s5, s6];
-                s1 = s2;
-              } else {
-                peg$currPos = s1;
-                s1 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s1;
-              s1 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c25;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e35); }
-        }
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = undefined;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f78(s1);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseoffset() {
-    let s0, s1, s2, s3, s4, s5, s6;
-
-    const key = peg$currPos * 68 + 56;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = input.charAt(peg$currPos);
-    if (s1.toLowerCase() === peg$c26) {
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e36); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f79();
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = input.charAt(peg$currPos);
-      if (peg$r0.test(s1)) {
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e14); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        s3 = peg$parseDIGIT();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseDIGIT();
-          if (s4 !== peg$FAILED) {
-            s3 = [s3, s4];
-            s2 = s3;
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c25;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e35); }
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$currPos;
-            s5 = peg$parseDIGIT();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseDIGIT();
-              if (s6 !== peg$FAILED) {
-                s5 = [s5, s6];
-                s4 = s5;
-              } else {
-                peg$currPos = s4;
-                s4 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s4;
-              s4 = peg$FAILED;
-            }
-            if (s4 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f80(s1, s2, s4);
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsedatetime_delim() {
-    let s0, s1, s2, s3;
-
-    const key = peg$currPos * 68 + 57;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = input.charAt(peg$currPos);
-    if (s0.toLowerCase() === peg$c27) {
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e37); }
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c28;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseDIGIT();
-        peg$silentFails--;
-        if (s3 !== peg$FAILED) {
-          peg$currPos = s2;
-          s2 = undefined;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s1 = [s1, s2];
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parsedatetime() {
-    let s0, s1, s2, s3, s4;
-
-    const key = peg$currPos * 68 + 58;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    s1 = peg$parsedate_part();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsedatetime_delim();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsetime_part();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseoffset();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s0 = peg$f81(s1, s3, s4);
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parsedate_part();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsedatetime_delim();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parsetime_part();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s0 = peg$f82(s1, s3);
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsedate_part();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$currPos;
-          peg$silentFails++;
-          s3 = peg$parsedatetime_delim();
-          peg$silentFails--;
-          if (s3 === peg$FAILED) {
-            s2 = undefined;
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
-          }
-          if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s0 = peg$f83(s1);
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          s1 = peg$parsetime_part();
-          if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$f84(s1);
-          }
-          s0 = s1;
-        }
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseS() {
-    let s0;
-
-    const key = peg$currPos * 68 + 59;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = input.charAt(peg$currPos);
-    if (peg$r9.test(s0)) {
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e39); }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseNL() {
-    let s0, s1, s2;
-
-    const key = peg$currPos * 68 + 60;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c29;
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e40); }
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 13) {
-        s1 = peg$c30;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e41); }
-      }
-      if (s1 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 10) {
-          s2 = peg$c29;
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
+          s5 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e40); }
         }
-        if (s2 !== peg$FAILED) {
-          s1 = [s1, s2];
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseNLS() {
-    let s0;
-
-    const key = peg$currPos * 68 + 61;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$parseNL();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseS();
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseEOF() {
-    let s0, s1;
-
-    const key = peg$currPos * 68 + 62;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    peg$silentFails++;
-    if (input.length > peg$currPos) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e1); }
-    }
-    peg$silentFails--;
-    if (s1 === peg$FAILED) {
-      s0 = undefined;
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseDIGIT() {
-    let s0;
-
-    const key = peg$currPos * 68 + 63;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = input.charAt(peg$currPos);
-    if (peg$r5.test(s0)) {
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e25); }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseHEX() {
-    let s0;
-
-    const key = peg$currPos * 68 + 64;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = input.charAt(peg$currPos);
-    if (peg$r6.test(s0)) {
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e26); }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseASCII_BASIC() {
-    let s0;
-
-    const key = peg$currPos * 68 + 65;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = input.charAt(peg$currPos);
-    if (peg$r10.test(s0)) {
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e42); }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseESCAPED() {
-    let s0, s1;
-
-    const key = peg$currPos * 68 + 66;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c31) {
-      s1 = peg$c31;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e43); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f85();
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c32) {
-        s1 = peg$c32;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e44); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$f86();
-      }
-      s0 = s1;
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c33) {
-          s1 = peg$c33;
-          peg$currPos += 2;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e45); }
-        }
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$f87();
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c34) {
-            s1 = peg$c34;
-            peg$currPos += 2;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e46); }
-          }
-          if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$f88();
-          }
-          s0 = s1;
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c35) {
-              s1 = peg$c35;
-              peg$currPos += 2;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e47); }
-            }
-            if (s1 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$f89();
-            }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c36) {
-                s1 = peg$c36;
-                peg$currPos += 2;
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseDIGIT();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseDIGIT();
+            if (s7 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 58) {
+                s8 = peg$c25;
+                peg$currPos++;
               } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e48); }
+                s8 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$e40); }
               }
-              if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$f90();
-              }
-              s0 = s1;
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                if (input.substr(peg$currPos, 2) === peg$c37) {
-                  s1 = peg$c37;
-                  peg$currPos += 2;
-                } else {
-                  s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$e49); }
-                }
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$f91();
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 2) === peg$c38) {
-                    s1 = peg$c38;
-                    peg$currPos += 2;
-                  } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e50); }
-                  }
-                  if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$f92();
-                  }
-                  s0 = s1;
-                  if (s0 === peg$FAILED) {
-                    s0 = peg$parseESCAPED_UNICODE();
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-    return s0;
-  }
-
-  function peg$parseESCAPED_UNICODE() {
-    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
-
-    const key = peg$currPos * 68 + 67;
-    const cached = peg$resultsCache[key];
-
-    if (cached) {
-      peg$currPos = cached.nextPos;
-
-      return cached.result;
-    }
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c39) {
-      s1 = peg$c39;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e51); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      s3 = peg$parseHEX();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parseHEX();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseHEX();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parseHEX();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseHEX();
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseHEX();
-                if (s8 !== peg$FAILED) {
-                  s9 = peg$parseHEX();
-                  if (s9 !== peg$FAILED) {
-                    s10 = peg$parseHEX();
-                    if (s10 !== peg$FAILED) {
-                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
-                      s2 = s3;
-                    } else {
-                      peg$currPos = s2;
-                      s2 = peg$FAILED;
-                    }
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseDIGIT();
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parseDIGIT();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
                   } else {
                     peg$currPos = s2;
                     s2 = peg$FAILED;
@@ -5315,37 +3588,47 @@ function peg$parse(input, options) {
         peg$currPos = s2;
         s2 = peg$FAILED;
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f93(s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    if (s2 !== peg$FAILED) {
+      s1 = input.substring(s1, peg$currPos);
+    } else {
+      s1 = s2;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsesecfragment();
+      if (s2 === peg$FAILED) {
+        s2 = null;
       }
+      peg$savedPos = s0;
+      s0 = peg$f56(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c40) {
-        s1 = peg$c40;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e52); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        s3 = peg$parseHEX();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseHEX();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseHEX();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseHEX();
-              if (s6 !== peg$FAILED) {
-                s3 = [s3, s4, s5, s6];
+      s1 = peg$currPos;
+      s2 = peg$currPos;
+      s3 = peg$parseDIGIT();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parseDIGIT();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c25;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e40); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseDIGIT();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseDIGIT();
+              if (s7 !== peg$FAILED) {
+                s3 = [s3, s4, s5, s6, s7];
                 s2 = s3;
               } else {
                 peg$currPos = s2;
@@ -5363,9 +3646,171 @@ function peg$parse(input, options) {
           peg$currPos = s2;
           s2 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s1 = input.substring(s1, peg$currPos);
+      } else {
+        s1 = s2;
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        peg$silentFails++;
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c25;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e40); }
+        }
+        peg$silentFails--;
+        if (s3 === peg$FAILED) {
+          s2 = undefined;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f94(s2);
+          s0 = peg$f57(s1);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseoffset() {
+    let s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = input.charAt(peg$currPos);
+    if (s1.toLowerCase() === peg$c26) {
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e41); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f58();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      s2 = input.charAt(peg$currPos);
+      if (peg$r1.test(s2)) {
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e6); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseDIGIT();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseDIGIT();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 58) {
+              s5 = peg$c25;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$e40); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseDIGIT();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseDIGIT();
+                if (s7 !== peg$FAILED) {
+                  s2 = [s2, s3, s4, s5, s6, s7];
+                  s1 = s2;
+                } else {
+                  peg$currPos = s1;
+                  s1 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s1;
+                s1 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s1;
+              s1 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s1;
+            s1 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s1;
+          s1 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+      if (s1 !== peg$FAILED) {
+        s0 = input.substring(s0, peg$currPos);
+      } else {
+        s0 = s1;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parsedatetime() {
+    let s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parsedate_part();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsedatetime_delim();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsetime_part();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseoffset();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f59(s1, s3, s4);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsedate_part();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsedatetime_delim();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsetime_part();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f60(s1, s3);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -5376,32 +3821,428 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c41) {
-          s1 = peg$c41;
-          peg$currPos += 2;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e53); }
-        }
+        s1 = peg$parsedate_part();
         if (s1 !== peg$FAILED) {
           s2 = peg$currPos;
-          s3 = peg$parseHEX();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parseHEX();
-            if (s4 !== peg$FAILED) {
-              s3 = [s3, s4];
-              s2 = s3;
-            } else {
-              peg$currPos = s2;
-              s2 = peg$FAILED;
-            }
+          peg$silentFails++;
+          s3 = peg$parsedatetime_delim();
+          peg$silentFails--;
+          if (s3 === peg$FAILED) {
+            s2 = undefined;
           } else {
             peg$currPos = s2;
             s2 = peg$FAILED;
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f95(s2);
+            s0 = peg$f61(s1);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsetime_part();
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$f62(s1);
+          }
+          s0 = s1;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parsedatetime_delim() {
+    let s0, s1, s2, s3;
+
+    s0 = input.charAt(peg$currPos);
+    if (s0.toLowerCase() === peg$c27) {
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e42); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 32) {
+        s1 = peg$c28;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e43); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        peg$silentFails++;
+        s3 = peg$parseDIGIT();
+        peg$silentFails--;
+        if (s3 !== peg$FAILED) {
+          peg$currPos = s2;
+          s2 = undefined;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseS() {
+    let s0;
+
+    s0 = input.charAt(peg$currPos);
+    if (peg$r14.test(s0)) {
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e44); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseNL() {
+    let s0, s1, s2;
+
+    if (input.charCodeAt(peg$currPos) === 10) {
+      s0 = peg$c29;
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e45); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 13) {
+        s1 = peg$c30;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e46); }
+      }
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 10) {
+          s2 = peg$c29;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e45); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseNLS() {
+    let s0;
+
+    s0 = peg$parseNL();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseS();
+    }
+
+    return s0;
+  }
+
+  function peg$parseEOF() {
+    let s0, s1;
+
+    s0 = peg$currPos;
+    peg$silentFails++;
+    if (input.length > peg$currPos) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+    }
+    peg$silentFails--;
+    if (s1 === peg$FAILED) {
+      s0 = undefined;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDIGIT() {
+    let s0;
+
+    s0 = input.charAt(peg$currPos);
+    if (peg$r10.test(s0)) {
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e30); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseHEX() {
+    let s0;
+
+    s0 = input.charAt(peg$currPos);
+    if (peg$r11.test(s0)) {
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e31); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseASCII_BASIC() {
+    let s0;
+
+    s0 = input.charAt(peg$currPos);
+    if (peg$r15.test(s0)) {
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e47); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseESCAPED() {
+    let s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 92) {
+      s1 = peg$c11;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e13); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = input.charAt(peg$currPos);
+      if (peg$r16.test(s2)) {
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e48); }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f63(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseESCAPED_UNICODE();
+    }
+
+    return s0;
+  }
+
+  function peg$parseESCAPED_UNICODE() {
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c31) {
+      s1 = peg$c31;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e49); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      s3 = peg$currPos;
+      s4 = peg$parseHEX();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseHEX();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseHEX();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseHEX();
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parseHEX();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseHEX();
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parseHEX();
+                  if (s10 !== peg$FAILED) {
+                    s11 = peg$parseHEX();
+                    if (s11 !== peg$FAILED) {
+                      s4 = [s4, s5, s6, s7, s8, s9, s10, s11];
+                      s3 = s4;
+                    } else {
+                      peg$currPos = s3;
+                      s3 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s3;
+                    s3 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s3;
+                  s3 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      if (s3 !== peg$FAILED) {
+        s2 = input.substring(s2, peg$currPos);
+      } else {
+        s2 = s3;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f64(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c32) {
+        s1 = peg$c32;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e50); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$currPos;
+        s4 = peg$parseHEX();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseHEX();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseHEX();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseHEX();
+              if (s7 !== peg$FAILED) {
+                s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          s2 = input.substring(s2, peg$currPos);
+        } else {
+          s2 = s3;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s0 = peg$f65(s2);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 2) === peg$c33) {
+          s1 = peg$c33;
+          peg$currPos += 2;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e51); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$currPos;
+          s3 = peg$currPos;
+          s4 = peg$parseHEX();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseHEX();
+            if (s5 !== peg$FAILED) {
+              s4 = [s4, s5];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+          if (s3 !== peg$FAILED) {
+            s2 = input.substring(s2, peg$currPos);
+          } else {
+            s2 = s3;
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f66(s2);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -5413,18 +4254,27 @@ function peg$parse(input, options) {
       }
     }
 
-    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
     return s0;
   }
 
 
   var nodes = [];
+  var inputText = input;
 
-  function genError(err, line, col) {
+  function resolveLineCol(off) {
+    var line = 1, col = 1;
+    for (var i = 0; i < off; i++) {
+      if (inputText.charCodeAt(i) === 10) { line++; col = 1; }
+      else { col++; }
+    }
+    return { line: line, column: col };
+  }
+
+  function genError(err, off) {
+    var pos = resolveLineCol(off);
     var ex = new Error(err);
-    ex.line = line;
-    ex.column = col;
+    ex.line = pos.line;
+    ex.column = pos.column;
     throw ex;
   }
 
@@ -5432,119 +4282,72 @@ function peg$parse(input, options) {
     nodes.push(node);
   }
 
-  function node(type, value, loc, key) {
-    var obj = { type: type, value: value, line: loc.start.line, column: loc.start.column };
+  function node(type, value, off, key) {
+    var obj = { type: type, value: value, offset: off };
     if (key) obj.key = key;
     return obj;
   }
 
-  function validateDate(dateStr, loc) {
-    var parts = dateStr.split('-');
-    var year = parseInt(parts[0], 10);
-    var month = parseInt(parts[1], 10);
-    var day = parseInt(parts[2], 10);
+  function validateDate(dateStr, off) {
+    var year = dateStr.charCodeAt(0) * 1000 + dateStr.charCodeAt(1) * 100 + dateStr.charCodeAt(2) * 10 + dateStr.charCodeAt(3) - 53328;
+    var month = (dateStr.charCodeAt(5) - 48) * 10 + dateStr.charCodeAt(6) - 48;
+    var day = (dateStr.charCodeAt(8) - 48) * 10 + dateStr.charCodeAt(9) - 48;
     if (month < 1 || month > 12) {
-      genError("Invalid date: month " + month + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid date: month " + month + " out of range.", off);
     }
     var maxDays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     if ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0) {
       maxDays[1] = 29;
     }
     if (day < 1 || day > maxDays[month - 1]) {
-      genError("Invalid date: day " + day + " out of range for month " + month + ".", loc.start.line, loc.start.column);
+      genError("Invalid date: day " + day + " out of range for month " + month + ".", off);
     }
   }
 
-  function validateTime(timeStr, loc) {
-    var base = timeStr.split('.')[0];
-    var parts = base.split(':');
-    var hour = parseInt(parts[0], 10);
-    var minute = parseInt(parts[1], 10);
-    var second = parseInt(parts[2], 10);
+  function validateTime(timeStr, off) {
+    var hour = (timeStr.charCodeAt(0) - 48) * 10 + timeStr.charCodeAt(1) - 48;
+    var minute = (timeStr.charCodeAt(3) - 48) * 10 + timeStr.charCodeAt(4) - 48;
+    var second = (timeStr.charCodeAt(6) - 48) * 10 + timeStr.charCodeAt(7) - 48;
     if (hour > 23) {
-      genError("Invalid time: hour " + hour + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid time: hour " + hour + " out of range.", off);
     }
     if (minute > 59) {
-      genError("Invalid time: minute " + minute + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid time: minute " + minute + " out of range.", off);
     }
     if (second > 59) {
-      genError("Invalid time: second " + second + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid time: second " + second + " out of range.", off);
     }
   }
 
-  function validateOffset(offsetStr, loc) {
-    if (offsetStr === "Z") return;
-    var parts = offsetStr.substring(1).split(':');
-    var hour = parseInt(parts[0], 10);
-    var minute = parseInt(parts[1], 10);
+  function validateOffset(offsetStr, off) {
+    if (offsetStr === "Z" || offsetStr === "z") return;
+    var hour = (offsetStr.charCodeAt(1) - 48) * 10 + offsetStr.charCodeAt(2) - 48;
+    var minute = (offsetStr.charCodeAt(4) - 48) * 10 + offsetStr.charCodeAt(5) - 48;
     if (hour > 23) {
-      genError("Invalid offset: hour " + hour + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid offset: hour " + hour + " out of range.", off);
     }
     if (minute > 59) {
-      genError("Invalid offset: minute " + minute + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid offset: minute " + minute + " out of range.", off);
     }
-  }
-
-  function isControlChar(ch) {
-    var code = ch.charCodeAt(0);
-    return (code >= 0x00 && code <= 0x08) || (code >= 0x0A && code <= 0x1F) || code === 0x7F;
-  }
-
-  function isControlCharMultiline(ch) {
-    var code = ch.charCodeAt(0);
-    // Same as isControlChar but allows newline (0x0A). Bare \r (0x0D) is still
-    // rejected; valid \r\n sequences are handled explicitly in the grammar rules.
-    return (code >= 0x00 && code <= 0x08) || (code >= 0x0B && code <= 0x1F) || code === 0x7F;
   }
 
   function stripUnderscores(str) {
-    return str.replace(/_/g, '');
+    return str.indexOf('_') === -1 ? str : str.replace(/_/g, '');
   }
 
-  function convertCodePoint(str, line, col) {
-    var num = parseInt("0x" + str);
+  function convertCodePoint(str) {
+    var num = parseInt(str, 16);
 
     if (
-      !isFinite(num) ||
-      Math.floor(num) != num ||
+      num !== num ||
       num < 0 ||
       num > 0x10FFFF ||
       (num > 0xD7FF && num < 0xE000)
     ) {
-      genError("Invalid Unicode escape code: " + str, line, col);
+      genError("Invalid Unicode escape code: " + str, offset());
     } else {
-      return fromCodePoint(num);
+      return String.fromCodePoint(num);
     }
-  }
-
-  function fromCodePoint() {
-    var MAX_SIZE = 0x4000;
-    var codeUnits = [];
-    var highSurrogate;
-    var lowSurrogate;
-    var index = -1;
-    var length = arguments.length;
-    if (!length) {
-      return '';
-    }
-    var result = '';
-    while (++index < length) {
-      var codePoint = Number(arguments[index]);
-      if (codePoint <= 0xFFFF) { // BMP code point
-        codeUnits.push(codePoint);
-      } else { // Astral code point; split in surrogate halves
-        // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-        codePoint -= 0x10000;
-        highSurrogate = (codePoint >> 10) + 0xD800;
-        lowSurrogate = (codePoint % 0x400) + 0xDC00;
-        codeUnits.push(highSurrogate, lowSurrogate);
-      }
-      if (index + 1 == length || codeUnits.length > MAX_SIZE) {
-        result += String.fromCharCode.apply(null, codeUnits);
-        codeUnits.length = 0;
-      }
-    }
-    return result;
   }
 
   peg$result = peg$startRuleFunction();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "peggy --cache -o lib/parser.js src/toml.pegjs",
+    "build": "peggy -o lib/parser.js src/toml.pegjs",
     "test": "node --test test/test_toml.js",
     "test:spec": "node test/spec-test.js",
     "test:spec:failures": "node test/spec-test.js --failures",

--- a/src/toml.pegjs
+++ b/src/toml.pegjs
@@ -1,10 +1,21 @@
 {
   var nodes = [];
+  var inputText = input;
 
-  function genError(err, line, col) {
+  function resolveLineCol(off) {
+    var line = 1, col = 1;
+    for (var i = 0; i < off; i++) {
+      if (inputText.charCodeAt(i) === 10) { line++; col = 1; }
+      else { col++; }
+    }
+    return { line: line, column: col };
+  }
+
+  function genError(err, off) {
+    var pos = resolveLineCol(off);
     var ex = new Error(err);
-    ex.line = line;
-    ex.column = col;
+    ex.line = pos.line;
+    ex.column = pos.column;
     throw ex;
   }
 
@@ -12,119 +23,72 @@
     nodes.push(node);
   }
 
-  function node(type, value, loc, key) {
-    var obj = { type: type, value: value, line: loc.start.line, column: loc.start.column };
+  function node(type, value, off, key) {
+    var obj = { type: type, value: value, offset: off };
     if (key) obj.key = key;
     return obj;
   }
 
-  function validateDate(dateStr, loc) {
-    var parts = dateStr.split('-');
-    var year = parseInt(parts[0], 10);
-    var month = parseInt(parts[1], 10);
-    var day = parseInt(parts[2], 10);
+  function validateDate(dateStr, off) {
+    var year = dateStr.charCodeAt(0) * 1000 + dateStr.charCodeAt(1) * 100 + dateStr.charCodeAt(2) * 10 + dateStr.charCodeAt(3) - 53328;
+    var month = (dateStr.charCodeAt(5) - 48) * 10 + dateStr.charCodeAt(6) - 48;
+    var day = (dateStr.charCodeAt(8) - 48) * 10 + dateStr.charCodeAt(9) - 48;
     if (month < 1 || month > 12) {
-      genError("Invalid date: month " + month + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid date: month " + month + " out of range.", off);
     }
     var maxDays = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     if ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0) {
       maxDays[1] = 29;
     }
     if (day < 1 || day > maxDays[month - 1]) {
-      genError("Invalid date: day " + day + " out of range for month " + month + ".", loc.start.line, loc.start.column);
+      genError("Invalid date: day " + day + " out of range for month " + month + ".", off);
     }
   }
 
-  function validateTime(timeStr, loc) {
-    var base = timeStr.split('.')[0];
-    var parts = base.split(':');
-    var hour = parseInt(parts[0], 10);
-    var minute = parseInt(parts[1], 10);
-    var second = parseInt(parts[2], 10);
+  function validateTime(timeStr, off) {
+    var hour = (timeStr.charCodeAt(0) - 48) * 10 + timeStr.charCodeAt(1) - 48;
+    var minute = (timeStr.charCodeAt(3) - 48) * 10 + timeStr.charCodeAt(4) - 48;
+    var second = (timeStr.charCodeAt(6) - 48) * 10 + timeStr.charCodeAt(7) - 48;
     if (hour > 23) {
-      genError("Invalid time: hour " + hour + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid time: hour " + hour + " out of range.", off);
     }
     if (minute > 59) {
-      genError("Invalid time: minute " + minute + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid time: minute " + minute + " out of range.", off);
     }
     if (second > 59) {
-      genError("Invalid time: second " + second + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid time: second " + second + " out of range.", off);
     }
   }
 
-  function validateOffset(offsetStr, loc) {
-    if (offsetStr === "Z") return;
-    var parts = offsetStr.substring(1).split(':');
-    var hour = parseInt(parts[0], 10);
-    var minute = parseInt(parts[1], 10);
+  function validateOffset(offsetStr, off) {
+    if (offsetStr === "Z" || offsetStr === "z") return;
+    var hour = (offsetStr.charCodeAt(1) - 48) * 10 + offsetStr.charCodeAt(2) - 48;
+    var minute = (offsetStr.charCodeAt(4) - 48) * 10 + offsetStr.charCodeAt(5) - 48;
     if (hour > 23) {
-      genError("Invalid offset: hour " + hour + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid offset: hour " + hour + " out of range.", off);
     }
     if (minute > 59) {
-      genError("Invalid offset: minute " + minute + " out of range.", loc.start.line, loc.start.column);
+      genError("Invalid offset: minute " + minute + " out of range.", off);
     }
-  }
-
-  function isControlChar(ch) {
-    var code = ch.charCodeAt(0);
-    return (code >= 0x00 && code <= 0x08) || (code >= 0x0A && code <= 0x1F) || code === 0x7F;
-  }
-
-  function isControlCharMultiline(ch) {
-    var code = ch.charCodeAt(0);
-    // Same as isControlChar but allows newline (0x0A). Bare \r (0x0D) is still
-    // rejected; valid \r\n sequences are handled explicitly in the grammar rules.
-    return (code >= 0x00 && code <= 0x08) || (code >= 0x0B && code <= 0x1F) || code === 0x7F;
   }
 
   function stripUnderscores(str) {
-    return str.replace(/_/g, '');
+    return str.indexOf('_') === -1 ? str : str.replace(/_/g, '');
   }
 
-  function convertCodePoint(str, line, col) {
-    var num = parseInt("0x" + str);
+  function convertCodePoint(str) {
+    var num = parseInt(str, 16);
 
     if (
-      !isFinite(num) ||
-      Math.floor(num) != num ||
+      num !== num ||
       num < 0 ||
       num > 0x10FFFF ||
       (num > 0xD7FF && num < 0xE000)
     ) {
-      genError("Invalid Unicode escape code: " + str, line, col);
+      genError("Invalid Unicode escape code: " + str, offset());
     } else {
-      return fromCodePoint(num);
+      return String.fromCodePoint(num);
     }
-  }
-
-  function fromCodePoint() {
-    var MAX_SIZE = 0x4000;
-    var codeUnits = [];
-    var highSurrogate;
-    var lowSurrogate;
-    var index = -1;
-    var length = arguments.length;
-    if (!length) {
-      return '';
-    }
-    var result = '';
-    while (++index < length) {
-      var codePoint = Number(arguments[index]);
-      if (codePoint <= 0xFFFF) { // BMP code point
-        codeUnits.push(codePoint);
-      } else { // Astral code point; split in surrogate halves
-        // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-        codePoint -= 0x10000;
-        highSurrogate = (codePoint >> 10) + 0xD800;
-        lowSurrogate = (codePoint % 0x400) + 0xDC00;
-        codeUnits.push(highSurrogate, lowSurrogate);
-      }
-      if (index + 1 == length || codeUnits.length > MAX_SIZE) {
-        result += String.fromCharCode.apply(null, codeUnits);
-        codeUnits.length = 0;
-      }
-    }
-    return result;
   }
 }
 
@@ -132,46 +96,52 @@ start
   = line*                               { return nodes }
 
 line
-  = S* expr:expression S* comment* (NL+ / EOF)
+  = S* expr:expression S* comment? (NL+ / EOF)
   / S+ (NL+ / EOF)
   / NL
 
 expression
-  = comment / path / tablearray / assignment
+  = comment / table_or_array_path / assignment
 
 comment
-  = '#' (!(NL / EOF) char:. { if (isControlChar(char)) genError("Control characters are not allowed in comments", location().start.line, location().start.column); return char })*
+  = '#' [\x09\x20-\x7E\x80-\uFFFF]*
 
-path
-  = '[' S* name:table_key S* ']'              { addNode(node('ObjectPath', name, location())) }
-
-tablearray
-  = '[' '[' S* name:table_key S* ']' ']'      { addNode(node('ArrayPath', name, location())) }
+// Unified '[' entry: try '[[' first for array-of-tables, fall back to '[' for table
+table_or_array_path
+  = '[' '[' S* name:table_key S* ']' ']'      { addNode(node('ArrayPath', name, offset())) }
+  / '[' S* name:table_key S* ']'              { addNode(node('ObjectPath', name, offset())) }
 
 table_key
   = parts:dot_ended_table_key_part+ name:table_key_part    { return parts.concat(name) }
   / name:table_key_part                                    { return [name] }
 
 table_key_part
-  = S* name:key S*                      { return name }
-  / S* name:quoted_key S*               { return name }
+  = S* name:simple_key S*               { return name }
 
 dot_ended_table_key_part
-  = S* name:key S* '.' S*               { return name }
-  / S* name:quoted_key S* '.' S*        { return name }
+  = S* name:simple_key S* '.'           { return name }
 
 assignment
-  = keys:inline_key S* '=' S* value:value { addNode(node('Assign', value, location(), keys)) }
+  = keys:inline_key S* '=' S* value:value { addNode(node('Assign', value, offset(), keys)) }
 
 key
-  = chars:ASCII_BASIC+ { return chars.join('') }
+  = $ASCII_BASIC+
 
 quoted_key
   = node:double_quoted_single_line_string { return node.value }
   / node:single_quoted_single_line_string { return node.value }
 
 value
-  = string / datetime / float / integer / boolean / array / inline_table
+  = string / number_or_date / boolean / array / inline_table
+
+// Unified entry point for numbers and dates — avoids backtracking across
+// datetime, float, and integer when they all start with digits.
+number_or_date
+  = sign:[+-]? 'inf'                                  { return node('Float', sign === '-' ? -Infinity : Infinity, offset()) }
+  / sign:[+-]? 'nan'                                  { return node('Float', NaN, offset()) }
+  / datetime
+  / float
+  / integer
 
 string
   = double_quoted_multiline_string
@@ -180,16 +150,16 @@ string
   / single_quoted_single_line_string
 
 double_quoted_multiline_string
-  = '"""' NL? body:mlb_body '"""'       { return node('String', body, location()) }
+  = '"""' NL? body:mlb_body '"""'       { return node('String', body, offset()) }
 
 double_quoted_single_line_string
-  = '"' chars:string_char* '"'          { return node('String', chars.join(''), location()) }
+  = '"' chars:string_char* '"'          { return node('String', chars.join(''), offset()) }
 
 single_quoted_multiline_string
-  = "'''" NL? body:mll_body "'''"       { return node('String', body, location()) }
+  = "'''" NL? body:mll_body "'''"       { return node('String', body, offset()) }
 
 single_quoted_single_line_string
-  = "'" chars:literal_char* "'"         { return node('String', chars.join(''), location()) }
+  = "'" chars:literal_char* "'"         { return node('String', chars.join(''), offset()) }
 
 // Multiline basic string body — follows the ABNF:
 // *mlb-content *( mlb-quotes 1*mlb-content ) [ mlb-quotes ]
@@ -203,9 +173,9 @@ mlb_body
 mlb_content
   = ESCAPED
   / mlb_escaped_newline
-  / '\\' . { genError("Invalid escape sequence", location().start.line, location().start.column) }
+  / '\\' . { genError("Invalid escape sequence", offset()) }
   / "\r\n" { return "\n" }
-  / !'"' char:. { if (isControlCharMultiline(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char }
+  / $[^"\\\x00-\x08\x0B-\x1F\x7F\r]+
 
 mlb_escaped_newline
   = '\\' S* NL NLS*                     { return '' }
@@ -228,7 +198,7 @@ mll_body
 
 mll_content
   = "\r\n" { return "\n" }
-  / !"'" char:. { if (isControlCharMultiline(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char }
+  / $[^'\x00-\x08\x0B-\x1F\x7F\r]+
 
 mll_quotes
   = "''" !"'"                            { return "''" }
@@ -240,90 +210,78 @@ mll_trailing
 
 string_char
   = ESCAPED
-  / '\\' . { genError("Invalid escape sequence", location().start.line, location().start.column) }
-  / !'"' !(NL / EOF) char:. { if (isControlChar(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char }
+  / '\\' . { genError("Invalid escape sequence", offset()) }
+  / $[^\"\\\x00-\x08\x0A-\x1F\x7F]+
 
 literal_char
-  = !"'" !(NL / EOF) char:. { if (isControlChar(char)) genError("Control characters are not allowed in strings", location().start.line, location().start.column); return char }
+  = $[^'\x00-\x08\x0A-\x1F\x7F]+
 
 float
-  = sign:[+-]? 'inf'                                  { return node('Float', sign === '-' ? -Infinity : Infinity, location()) }
-  / sign:[+-]? 'nan'                                  { return node('Float', NaN, location()) }
-  / left:float_or_int_text [eE] right:float_exp_text  { return node('Float', parseFloat(stripUnderscores(left + 'e' + right)), location()) }
-  / text:float_text                                   { return node('Float', parseFloat(stripUnderscores(text)), location()) }
+  = left:float_or_int_text [eE] right:float_exp_text  { return node('Float', parseFloat(stripUnderscores(left + 'e' + right)), offset()) }
+  / text:float_text                                   { return node('Float', parseFloat(stripUnderscores(text)), offset()) }
 
 float_text
-  = sign:[+-]? digits:FLOAT_DEC_INT '.' frac:DEC_INT  { return (sign === '-' ? '-' : '') + digits + '.' + frac }
+  = sign:[+-]? digits:FLOAT_DEC_INT '.' frac:$DEC_DIGIT_SEQ  { return (sign === '-' ? '-' : '') + digits + '.' + frac }
 
 float_or_int_text
-  = sign:[+-]? digits:FLOAT_DEC_INT '.' frac:DEC_INT  { return (sign === '-' ? '-' : '') + digits + '.' + frac }
+  = sign:[+-]? digits:FLOAT_DEC_INT '.' frac:$DEC_DIGIT_SEQ  { return (sign === '-' ? '-' : '') + digits + '.' + frac }
   / sign:[+-]? digits:FLOAT_DEC_INT                    { return (sign === '-' ? '-' : '') + digits }
 
 // Integer part of floats follows same no-leading-zero rule as integers
 FLOAT_DEC_INT
   = '0' { return '0' }
-  / DEC_INT_NOZERO
+  / $DEC_INT_NOZERO_SEQ
 
 float_exp_text
-  = sign:[+-]? digits:DEC_INT                          { return (sign || '') + digits }
+  = sign:[+-]? digits:$DEC_DIGIT_SEQ                          { return (sign || '') + digits }
 
 integer
-  = '0x' digits:HEX_INT                               { return node('Integer', parseInt(stripUnderscores(digits), 16), location()) }
-  / '0o' digits:OCT_INT                                { return node('Integer', parseInt(stripUnderscores(digits), 8), location()) }
-  / '0b' digits:BIN_INT                                { return node('Integer', parseInt(stripUnderscores(digits), 2), location()) }
-  / text:dec_integer_text                              { return node('Integer', parseInt(stripUnderscores(text), 10), location()) }
+  = '0x' digits:$HEX_DIGIT_SEQ                               { return node('Integer', parseInt(stripUnderscores(digits), 16), offset()) }
+  / '0o' digits:$OCT_DIGIT_SEQ                                { return node('Integer', parseInt(stripUnderscores(digits), 8), offset()) }
+  / '0b' digits:$BIN_DIGIT_SEQ                                { return node('Integer', parseInt(stripUnderscores(digits), 2), offset()) }
+  / text:dec_integer_text                              { return node('Integer', parseInt(stripUnderscores(text), 10), offset()) }
 
 dec_integer_text
   = sign:[+-]? '0' !([0-9_]) !'.'                     { return (sign || '') + '0' }
-  / sign:[+-]? digits:DEC_INT_NOZERO !'.'             { return (sign || '') + digits }
+  / sign:[+-]? digits:$DEC_INT_NOZERO_SEQ !'.'             { return (sign || '') + digits }
 
-DEC_INT_NOZERO
-  = head:[1-9] tail:([_]? [0-9])* { return head + tail.map(function(p) { return p.join('') }).join('') }
+DEC_INT_NOZERO_SEQ
+  = [1-9] ([_]? [0-9])*
 
-// Digit sequences with underscore validation:
-// - Underscores must be between digits (not leading, trailing, or consecutive)
-DEC_INT
-  = head:[0-9] tail:([_]? [0-9])* { return head + tail.map(function(p) { return p.join('') }).join('') }
+// Digit sequences - captured as text with $()
+DEC_DIGIT_SEQ
+  = [0-9] ([_]? [0-9])*
 
-HEX_INT
-  = head:[0-9a-fA-F] tail:([_]? [0-9a-fA-F])* { return head + tail.map(function(p) { return p.join('') }).join('') }
+HEX_DIGIT_SEQ
+  = [0-9a-fA-F] ([_]? [0-9a-fA-F])*
 
-OCT_INT
-  = head:[0-7] tail:([_]? [0-7])* { return head + tail.map(function(p) { return p.join('') }).join('') }
+OCT_DIGIT_SEQ
+  = [0-7] ([_]? [0-7])*
 
-BIN_INT
-  = head:[01] tail:([_]? [01])* { return head + tail.map(function(p) { return p.join('') }).join('') }
+BIN_DIGIT_SEQ
+  = [01] ([_]? [01])*
 
 boolean
-  = 'true'                              { return node('Boolean', true, location()) }
-  / 'false'                             { return node('Boolean', false, location()) }
+  = 'true'                              { return node('Boolean', true, offset()) }
+  / 'false'                             { return node('Boolean', false, offset()) }
 
 array
-  = '[' array_sep* ']'                                 { return node('Array', [], location()) }
-  / '[' value:array_value? ']'                         { return node('Array', value ? [value] : [], location()) }
-  / '[' values:array_value_list+ ']'                   { return node('Array', values, location()) }
-  / '[' values:array_value_list+ value:array_value ']' { return node('Array', values.concat(value), location()) }
-
-array_value
-  = array_sep* value:value array_sep*                  { return value }
-
-array_value_list
-  = array_sep* value:value array_sep* ',' array_sep*   { return value }
+  = '[' array_sep* ']'                                 { return node('Array', [], offset()) }
+  / '[' array_sep* head:value tail:(array_sep* ',' array_sep* v:value { return v })* array_sep* ','? array_sep* ']' {
+      tail.unshift(head); return node('Array', tail, offset())
+    }
 
 array_sep
   = S / NL / comment
 
 inline_table
-  = '{' inline_sep* '}'                                                                          { return node('InlineTable', [], location()) }
-  / '{' inline_sep* entries:inline_table_entry_list inline_sep* last:inline_table_entry inline_sep* '}' { return node('InlineTable', entries.concat(last), location()) }
-  / '{' inline_sep* entries:inline_table_entry_list inline_sep* '}'                              { return node('InlineTable', entries, location()) }
-  / '{' inline_sep* entry:inline_table_entry inline_sep* '}'                                     { return node('InlineTable', [entry], location()) }
-
-inline_table_entry_list
-  = entries:(inline_sep* e:inline_table_entry inline_sep* ',' { return e })+                     { return entries }
+  = '{' inline_sep* '}' { return node('InlineTable', [], offset()) }
+  / '{' inline_sep* head:inline_table_entry tail:(inline_sep* ',' inline_sep* e:inline_table_entry { return e })* inline_sep* ','? inline_sep* '}' {
+      tail.unshift(head); return node('InlineTable', tail, offset())
+    }
 
 inline_table_entry
-  = keys:inline_key S* '=' S* value:value                                                        { return node('InlineTableValue', value, location(), keys) }
+  = keys:inline_key S* '=' S* value:value                                                        { return node('InlineTableValue', value, offset(), keys) }
 
 inline_sep
   = S / NL / comment
@@ -340,28 +298,27 @@ simple_key
   / quoted_key
 
 secfragment
-  = '.' digits:DIGIT+                                  { return "." + digits.join('') }
+  = $('.' DIGIT+)
 
 date_part
-  = d:(DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT)  { return d.join('') }
+  = $(DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT)
 
 time_part
-  = t:(DIGIT DIGIT ':' DIGIT DIGIT ':' DIGIT DIGIT secfragment?) { return t.join('') }
-  / t:(DIGIT DIGIT ':' DIGIT DIGIT) !(':') { return t.join('') + ':00' }
+  = t:$(DIGIT DIGIT ':' DIGIT DIGIT ':' DIGIT DIGIT) frac:secfragment? { return frac ? t + frac : t }
+  / t:$(DIGIT DIGIT ':' DIGIT DIGIT) !(':') { return t + ':00' }
 
 offset
   = 'Z'i                                              { return "Z" }
-  / sign:[+-] h:(DIGIT DIGIT) ':' m:(DIGIT DIGIT)     { return sign + h.join('') + ":" + m.join('') }
+  / $(sign:[+-] DIGIT DIGIT ':' DIGIT DIGIT)
+
+datetime
+  = d:date_part datetime_delim t:time_part o:offset    { var off = offset(); validateDate(d, off); validateTime(t, off); validateOffset(o, off); return node('Date', new Date(d + "T" + t + o), off) }
+  / d:date_part datetime_delim t:time_part             { var off = offset(); validateDate(d, off); validateTime(t, off); return node('LocalDateTime', d + "T" + t, off) }
+  / d:date_part !datetime_delim                         { var off = offset(); validateDate(d, off); return node('LocalDate', d, off) }
+  / t:time_part                                        { var off = offset(); validateTime(t, off); return node('LocalTime', t, off) }
 
 datetime_delim
   = 'T'i / ' ' &DIGIT
-
-datetime
-  = d:date_part datetime_delim t:time_part o:offset    { validateDate(d, location()); validateTime(t, location()); validateOffset(o, location()); return node('Date', new Date(d + "T" + t + o), location()) }
-  / d:date_part datetime_delim t:time_part             { validateDate(d, location()); validateTime(t, location()); return node('LocalDateTime', d + "T" + t, location()) }
-  / d:date_part !datetime_delim                         { validateDate(d, location()); return node('LocalDate', d, location()) }
-  / t:time_part                                        { validateTime(t, location()); return node('LocalTime', t, location()) }
-
 
 S                = [ \t]
 NL               = "\n" / "\r" "\n"
@@ -370,15 +327,8 @@ EOF              = !.
 DIGIT            = [0-9]
 HEX              = [0-9a-fA-F]
 ASCII_BASIC      = [A-Za-z0-9_\-]
-ESCAPED          = '\\"'                { return '"'  }
-                 / '\\\\'               { return '\\' }
-                 / '\\b'                { return '\b' }
-                 / '\\t'                { return '\t' }
-                 / '\\n'                { return '\n' }
-                 / '\\f'                { return '\f' }
-                 / '\\r'                { return '\r' }
-                 / '\\e'                { return '\x1B' }
+ESCAPED          = '\\' ch:[\"\\btnfre] { return ch === 'n' ? '\n' : ch === 't' ? '\t' : ch === 'r' ? '\r' : ch === '\\' ? '\\' : ch === '"' ? '"' : ch === 'b' ? '\b' : ch === 'f' ? '\f' : '\x1B' }
                  / ESCAPED_UNICODE
-ESCAPED_UNICODE  = "\\U" digits:(HEX HEX HEX HEX HEX HEX HEX HEX) { return convertCodePoint(digits.join('')) }
-                 / "\\u" digits:(HEX HEX HEX HEX) { return convertCodePoint(digits.join('')) }
-                 / "\\x" digits:(HEX HEX) { return convertCodePoint(digits.join('')) }
+ESCAPED_UNICODE  = "\\U" digits:$(HEX HEX HEX HEX HEX HEX HEX HEX) { return convertCodePoint(digits) }
+                 / "\\u" digits:$(HEX HEX HEX HEX) { return convertCodePoint(digits) }
+                 / "\\x" digits:$(HEX HEX) { return convertCodePoint(digits) }


### PR DESCRIPTION
Don't be fooled — it's only 5x because it was so slow before.

This PR tackles a lot of low-hanging fruit performance wise:

* Disable peggy cache
* Replace arrays with `Set`s for O(1) lookups
* Use `offset()` instead of `location()` for error pos tracking
* Reduce backtracking in the grammar

Before:

```
classic (v0.4.0 example): 5000 iterations in 1476ms (3,388 ops/sec)
comprehensive (v1.0.0 features): 5000 iterations in 2470ms (2,024 ops/sec)
```

After:

```
classic (v0.4.0 example): 5000 iterations in 260ms (19,248 ops/sec)
comprehensive (v1.0.0 features): 5000 iterations in 526ms (9,505 ops/sec)
```