### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/BinaryMuse/toml-node.git"
+    "url": "git+https://github.com/BinaryMuse/toml-node.git"
   },
   "keywords": [
     "toml",


### PR DESCRIPTION
## Summary
- update the package repository URL from `git://` to `git+https://`
- leave runtime code, dependencies, package version, entry points, types, license, and package contents unchanged

## Validation
- `npm view toml --json`
- metadata assertion for package identity, entry points, types, license, and repository fields
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run build`
- `npm test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: `npm run test:spec` currently requires the external `.binarymuse/toml-test` fixture checkout and cannot run from a fresh clone without that data.